### PR TITLE
Add a __pre_init function to be called at the start of the reset handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ panic-abort = "0.2.0"
 
 [features]
 device = []
+pre_init = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,3 @@ panic-abort = "0.2.0"
 
 [features]
 device = []
-pre_init = []

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -9,6 +9,7 @@ main() {
         alignment
         minimal
         main
+        pre_init
         state
     )
     local fail_examples=(

--- a/examples/pre_init.rs
+++ b/examples/pre_init.rs
@@ -4,11 +4,9 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry, exception, pre_init)]
+#[macro_use(entry, pre_init)]
 extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
-
-use rt::ExceptionFrame;
 
 pre_init!(disable_watchdog);
 
@@ -22,15 +20,3 @@ entry!(main);
 fn main() -> ! {
     loop {}
 }
-
-// the hard fault handler
-exception!(HardFault, hard_fault);
-
-fn hard_fault(_ef: &ExceptionFrame) -> ! {
-    loop {}
-}
-
-// the default exception handler
-exception!(*, default_handler);
-
-fn default_handler(_irqn: i16) {}

--- a/examples/pre_init.rs
+++ b/examples/pre_init.rs
@@ -1,0 +1,36 @@
+//! `cortex-m-rt` based program with a function run before RAM is initialized.
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+#[macro_use(entry, exception, pre_init)]
+extern crate cortex_m_rt as rt;
+extern crate panic_semihosting;
+
+use rt::ExceptionFrame;
+
+pre_init!(disable_watchdog);
+
+unsafe fn disable_watchdog() {
+    // Do what you need to disable the watchdog.
+}
+
+// the program entry point
+entry!(main);
+
+fn main() -> ! {
+    loop {}
+}
+
+// the hard fault handler
+exception!(HardFault, hard_fault);
+
+fn hard_fault(_ef: &ExceptionFrame) -> ! {
+    loop {}
+}
+
+// the default exception handler
+exception!(*, default_handler);
+
+fn default_handler(_irqn: i16) {}

--- a/link.x.in
+++ b/link.x.in
@@ -51,6 +51,11 @@ PROVIDE(UserHardFault = DefaultUserHardFault);
 /* # Interrupt vectors */
 EXTERN(__INTERRUPTS); /* `static` variable similar to `__EXCEPTIONS` */
 
+/* # Pre-initialization function */
+/* If the user overrides this using the `pre_init!` macro or by creating a `__pre_init` function,
+   then the function this points to will be called before the RAM is initialized. */
+PROVIDE(__pre_init = 0);
+
 /* # Sections */
 SECTIONS
 {

--- a/link.x.in
+++ b/link.x.in
@@ -54,7 +54,7 @@ EXTERN(__INTERRUPTS); /* `static` variable similar to `__EXCEPTIONS` */
 /* # Pre-initialization function */
 /* If the user overrides this using the `pre_init!` macro or by creating a `__pre_init` function,
    then the function this points to will be called before the RAM is initialized. */
-PROVIDE(__pre_init = 1);
+PROVIDE(__pre_init = DefaultPreInit);
 
 /* # Sections */
 SECTIONS

--- a/link.x.in
+++ b/link.x.in
@@ -54,7 +54,7 @@ EXTERN(__INTERRUPTS); /* `static` variable similar to `__EXCEPTIONS` */
 /* # Pre-initialization function */
 /* If the user overrides this using the `pre_init!` macro or by creating a `__pre_init` function,
    then the function this points to will be called before the RAM is initialized. */
-PROVIDE(__pre_init = 0);
+PROVIDE(__pre_init = 1);
 
 /* # Sections */
 SECTIONS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,7 +491,7 @@ pub unsafe extern "C" fn Reset() -> ! {
     }
 
     let pre_init: unsafe extern "C" fn() = __pre_init;
-    if pre_init as usize != 0 {
+    if pre_init as usize != 1 {
         pre_init();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,11 +237,10 @@
 //! have a size of 32 vectors (on ARMv6-M) or 240 vectors (on ARMv7-M). This array is located after
 //! `__EXCEPTIONS` in the `.vector_table` section.
 //!
-//! - `__pre_init`. This is a function to be run before RAM is initialized. It defaults pointing at
-//! `1` and if not changed to point to another address, usually by calling the `pre_init!` macro,
-//! the `_pre_init` function is skipped. The function cannot default to `0` as the compiler
-//! optimizes out the check for `0` under the assumption that a function pointer cannot point to
-//! `0`.
+//! - `__pre_init`. This is a function to be run before RAM is initialized. It defaults to an empty
+//! function. The function called can be changed by calling the `pre_init!` macro. The empty
+//! function is not optimized out by default, but if an empty function is passed to `pre_init!` the
+//! function call will be optimized out.
 //!
 //! If you override any exception handler you'll find it as an unmangled symbol, e.g. `SysTick` or
 //! `SVCall`, in the output of `objdump`,
@@ -493,9 +492,7 @@ pub unsafe extern "C" fn Reset() -> ! {
     }
 
     let pre_init: unsafe extern "C" fn() = __pre_init;
-    if pre_init as usize != 1 {
-        pre_init();
-    }
+    pre_init();
 
     // Initialize RAM
     r0::zero_bss(&mut __sbss, &mut __ebss);
@@ -551,6 +548,10 @@ pub unsafe extern "C" fn DefaultUserHardFault() {
         ptr::read_volatile(&0u8);
     }
 }
+
+#[doc(hidden)]
+#[no_mangle]
+pub unsafe extern "C" fn DefaultPreInit() {}
 
 /// Macro to define the entry point of the program
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,8 +238,10 @@
 //! `__EXCEPTIONS` in the `.vector_table` section.
 //!
 //! - `__pre_init`. This is a function to be run before RAM is initialized. It defaults pointing at
-//! `0` and if not changed to point to another address, usually by calling the `pre_init!` macro,
-//! the `_pre_init` function is skipped.
+//! `1` and if not changed to point to another address, usually by calling the `pre_init!` macro,
+//! the `_pre_init` function is skipped. The function cannot default to `0` as the compiler
+//! optimizes out the check for `0` under the assumption that a function pointer cannot point to
+//! `0`.
 //!
 //! If you override any exception handler you'll find it as an unmangled symbol, e.g. `SysTick` or
 //! `SVCall`, in the output of `objdump`,


### PR DESCRIPTION
I needed this for a project so I went ahead and rebased and tweaked @jcsoo 's changes from #71. I will admit, I got a little impatient waiting and that also played into why I did this. If either @jcsoo or @japaric have an issue with this PR, please let me know and I will remove it. I apologize for toes that I have stepped on.

Now onto the PR. This is possibly the simplest implementation that is possible. No nightly features were used in this implementation. Also, there is no hand-holding for the end user; if they want to mess with uninitialized statics, that is on them.

If you would like me to add more documentation, please let me know what you would like to see.

Fixes #17 