### PR TITLE
refactor the linker script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
 
     - env: TARGET=thumbv6m-none-eabi
       rust: stable
-      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv6m-none-eabi CC=clang
@@ -16,7 +15,6 @@ matrix:
 
     - env: TARGET=thumbv7m-none-eabi
       rust: stable
-      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7m-none-eabi CC=clang
@@ -25,7 +23,6 @@ matrix:
 
     - env: TARGET=thumbv7em-none-eabi
       rust: stable
-      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabi CC=clang
@@ -34,7 +31,6 @@ matrix:
 
     - env: TARGET=thumbv7em-none-eabihf
       rust: stable
-      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabihf CC=clang
@@ -43,28 +39,25 @@ matrix:
 
     - env: TARGET=thumbv6m-none-eabi
       rust: nightly
-      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7m-none-eabi
       rust: nightly
-      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabi
       rust: nightly
-      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabihf
       rust: nightly
-      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
 before_install: set -e
 
 install:
   - bash ci/install.sh
+  - export PATH="$PATH:$PWD/gcc/bin"
 
 script:
   - bash ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ matrix:
 
     - env: TARGET=thumbv6m-none-eabi
       rust: stable
-      addons:
-        apt:
-          packages:
-            - gcc-arm-none-eabi
+      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv6m-none-eabi CC=clang
@@ -19,10 +16,7 @@ matrix:
 
     - env: TARGET=thumbv7m-none-eabi
       rust: stable
-      addons:
-        apt:
-          packages:
-            - gcc-arm-none-eabi
+      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7m-none-eabi CC=clang
@@ -31,10 +25,7 @@ matrix:
 
     - env: TARGET=thumbv7em-none-eabi
       rust: stable
-      addons:
-        apt:
-          packages:
-            - gcc-arm-none-eabi
+      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabi CC=clang
@@ -43,10 +34,7 @@ matrix:
 
     - env: TARGET=thumbv7em-none-eabihf
       rust: stable
-      addons:
-        apt:
-          packages:
-            - gcc-arm-none-eabi
+      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabihf CC=clang
@@ -55,34 +43,22 @@ matrix:
 
     - env: TARGET=thumbv6m-none-eabi
       rust: nightly
-      addons:
-        apt:
-          packages:
-            - gcc-arm-none-eabi
+      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7m-none-eabi
       rust: nightly
-      addons:
-        apt:
-          packages:
-            - gcc-arm-none-eabi
+      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabi
       rust: nightly
-      addons:
-        apt:
-          packages:
-            - gcc-arm-none-eabi
+      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabihf
       rust: nightly
-      addons:
-        apt:
-          packages:
-            - gcc-arm-none-eabi
+      sudo: true
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
 before_install: set -e

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ r0 = "0.2.1"
 
 [dev-dependencies]
 panic-semihosting = "0.3.0"
+panic-abort = "0.2.0"
 
 [features]
 device = []

--- a/build.rs
+++ b/build.rs
@@ -42,12 +42,12 @@ INCLUDE device.x"#
     writeln!(
         f,
         r#"
-ASSERT(__einterrupts - __eexceptions <= 0x{:x}, "
-There can't be more than {} interrupt handlers. This may be a bug in
-your device crate, or you may have registered more than 240 interrupt
+ASSERT(SIZEOF(.vector_table) <= 0x{:x}, "
+There can't be more than {1} interrupt handlers. This may be a bug in
+your device crate, or you may have registered more than {1} interrupt
 handlers.");
 "#,
-        max_int_handlers * 4,
+        max_int_handlers * 4 + 0x40,
         max_int_handlers
     ).unwrap();
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -5,9 +5,9 @@ main() {
         rustup target add $TARGET
 
         if [ ${CC:-gcc} = gcc ]; then
-            sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
-            sudo apt-get update -q
-            sudo apt-get install gcc-arm-embedded -y
+            mkdir gcc
+
+            curl -L https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2?revision=bc2c96c0-14b5-4bb4-9f18-bceb4050fee7?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2018-q2-update | tar --strip-components=1 -C gcc -xj
         fi
     fi
 }

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -3,6 +3,12 @@ set -euxo pipefail
 main() {
     if [ $TARGET != x86_64-unknown-linux-gnu ]; then
         rustup target add $TARGET
+
+        if [ ${CC:-gcc} = gcc ]; then
+            sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
+            sudo apt-get update -q
+            sudo apt-get install gcc-arm-embedded -y
+        fi
     fi
 }
 

--- a/examples/alignment.rs
+++ b/examples/alignment.rs
@@ -1,0 +1,45 @@
+//! This is not an example; this is a link-pass test
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+#[macro_use(entry, exception)]
+extern crate cortex_m_rt as rt;
+extern crate panic_abort;
+
+use core::ptr;
+
+use rt::ExceptionFrame;
+
+entry!(main);
+
+static mut BSS1: u16 = 0;
+static mut BSS2: u8 = 0;
+static mut DATA1: u8 = 1;
+static mut DATA2: u16 = 1;
+static RODATA1: &[u8; 3] = b"012";
+static RODATA2: &[u8; 2] = b"34";
+
+fn main() -> ! {
+    unsafe {
+        let _bss1 = ptr::read_volatile(&BSS1);
+        let _bss2 = ptr::read_volatile(&BSS2);
+        let _data1 = ptr::read_volatile(&DATA1);
+        let _data2 = ptr::read_volatile(&DATA2);
+        let _rodata1 = ptr::read_volatile(&RODATA1);
+        let _rodata2 = ptr::read_volatile(&RODATA2);
+    }
+
+    loop {}
+}
+
+exception!(HardFault, hard_fault);
+
+fn hard_fault(_ef: &ExceptionFrame) -> ! {
+    loop {}
+}
+
+exception!(*, default_handler);
+
+fn default_handler(_irqn: i16) {}

--- a/link.x.in
+++ b/link.x.in
@@ -48,87 +48,86 @@ PROVIDE(SysTick = DefaultHandler);
 /* # Interrupt vectors */
 EXTERN(__INTERRUPTS); /* `static` variable similar to `__EXCEPTIONS` */
 
-/* # User overridable symbols I */
-/* Lets the user place the stack in a different RAM region */
-PROVIDE(_stack_start = ORIGIN(RAM) + LENGTH(RAM));
-
 /* # Sections */
 SECTIONS
 {
+  PROVIDE(_stack_start = ORIGIN(RAM) + LENGTH(RAM));
+
   /* ## Sections in FLASH */
   /* ### Vector table */
-  .vector_table ORIGIN(FLASH) : ALIGN(4)
+  .vector_table ORIGIN(FLASH) :
   {
     /* Initial Stack Pointer (SP) value */
-    __STACK_START = .; /* Just to get a nicer name in the disassembly */
     LONG(_stack_start);
 
     /* Reset vector */
-    KEEP(*(.vector_table.reset_vector)); /* this is `__RESET_VECTOR` symbol */
-    __reset_vector = ABSOLUTE(.);
+    KEEP(*(.vector_table.reset_vector)); /* this is the `__RESET_VECTOR` symbol */
+    __reset_vector = .;
 
     /* Exceptions */
-    KEEP(*(.vector_table.exceptions)); /* this is `__EXCEPTIONS` symbol */
-    __eexceptions = ABSOLUTE(.);
+    KEEP(*(.vector_table.exceptions)); /* this is the `__EXCEPTIONS` symbol */
+    __eexceptions = .;
 
     /* Device specific interrupts */
-    KEEP(*(.vector_table.interrupts)); /* this is `__INTERRUPTS` symbol */
-    __einterrupts = ABSOLUTE(.);
+    KEEP(*(.vector_table.interrupts)); /* this is the `__INTERRUPTS` symbol */
   } > FLASH
+
+  PROVIDE(_stext = ADDR(.vector_table) + SIZEOF(.vector_table));
 
   /* ### .text */
   .text _stext :
   {
     *(.text .text.*);
-    __etext = ABSOLUTE(.);
   } > FLASH
 
   /* ### .rodata */
   .rodata :
   {
-    . = ALIGN(4); /* 4-byte align the start (VMA) of this section */
-    /* __srodata = ABSOLUTE(.); */
-
     *(.rodata .rodata.*);
 
-    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
-    __erodata = ABSOLUTE(.);
+    /* 4-byte align the end (VMA) of this section */
+    /* WHY? To my knowledge there's no way to indicate the alignment of *LMA* so we align *this*
+    section with the goal of using its end address as the LMA of .data */
+    . = ALIGN(4);
   } > FLASH
 
   /* ## Sections in RAM */
   /* ### .data */
-  .data : AT(__erodata) /* LMA */
+  .data : AT(ADDR(.rodata) + SIZEOF(.rodata)) /* LMA */
   {
-    . = ALIGN(4); /* 4-byte align the start (VMA) of this section */
-    __sdata = ABSOLUTE(.);
-
     *(.data .data.*);
 
     . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
-    __edata = ABSOLUTE(.);
   } > RAM
+
+  /* VMA of .data */
+  __sdata = ADDR(.data);
+  __edata = ADDR(.data) + SIZEOF(.data);
+
+  /* LMA of .data */
+  __sidata = LOADADDR(.data);
 
   /* ### .bss */
   .bss :
   {
-    . = ALIGN(4); /* 4-byte align the start (VMA) of this section */
-    __sbss = ABSOLUTE(.);
-
     *(.bss .bss.*);
 
     . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
-    __ebss = ABSOLUTE(.);
   } > RAM
 
-  /* ## Fake output .got section */
+  __sbss = ADDR(.bss);
+  __ebss = ADDR(.bss) + SIZEOF(.bss);
+
+  /* Place the heap right after `.bss` */
+  __sheap = ADDR(.bss) + SIZEOF(.bss);
+
+  /* ## .got */
   /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
      the input files and raise an error if relocatable code is found */
-  .got :
+  .got (NOLOAD) :
   {
-    __sgot = ABSOLUTE(.);
     KEEP(*(.got .got.*));
-    __egot = ABSOLUTE(.);
-  } > FLASH
+  }
 
   /* ## Discarded sections */
   /DISCARD/ :
@@ -138,67 +137,56 @@ SECTIONS
   }
 }
 
-/* # User overridable symbols II */
-/* (The user overridable symbols are split in two parts because LLD demands that the RHS of PROVIDE
-    to be defined before the PROVIDE invocation) */
-/* Lets the user override this to place .text a bit further than the vector table. Required by
-microcontrollers that store their configuration right after the vector table. */
-PROVIDE(_stext = __einterrupts);
-
-/* # Hardcoded symbols */
-/* Place `.bss` at the start of the RAM region */
-__sidata = LOADADDR(.data);
-/* Place the heap right after `.bss` and `.data` */
-__sheap = __ebss;
-
-/* # Sanity checks */
-
 /* Do not exceed this mark in the error messages below                                    | */
-ASSERT(__reset_vector == ORIGIN(FLASH) + 0x8, "
-cortex-m-rt: The reset vector is missing. This is a bug in cortex-m-rt. Please file a bug
-report at: https://github.com/japaric/cortex-m-rt/issues");
+/* # Alignment checks */
+ASSERT(ORIGIN(FLASH) % 4 == 0, "
+ERROR(cortex-m-rt): the start of the FLASH region must be 4-byte aligned");
 
-ASSERT(__eexceptions - ORIGIN(FLASH) == 0x40, "
-cortex-m-rt: The exception vectors are missing. This is a bug in cortex-m-rt. Please file
-a bug report at: https://github.com/japaric/cortex-m-rt/issues");
+ASSERT(ORIGIN(RAM) % 4 == 0, "
+ERROR(cortex-m-rt): the start of the RAM region must be 4-byte aligned");
 
-ASSERT(__sheap >= __ebss, "
-cortex-m-rt: The heap overlaps with the .bss section. This is a bug in cortex-m-rt. Please
-file a bug report at: https://github.com/japaric/cortex-m-rt/issues");
+ASSERT(__sdata % 4 == 0 && __edata % 4 == 0, "
+BUG(cortex-m-rt): .data is not 4-byte aligned");
 
-ASSERT(__sheap >= __edata, "
-cortex-m-rt: The heap overlaps with the .data section. This is a bug in cortex-m-rt.
-Please file a bug report at: https://github.com/japaric/cortex-m-rt/issues");
+ASSERT(__sidata % 4 == 0, "
+BUG(cortex-m-rt): the LMA of .data is not 4-byte aligned");
 
-ASSERT(__einterrupts - __eexceptions > 0, "
-cortex-m-rt: The interrupt vectors are missing. Possible solutions, from most likely to
-less likely:
-- Link to a device crate
+ASSERT(__sbss % 4 == 0 && __ebss % 4 == 0, "
+BUG(cortex-m-rt): .bss is not 4-byte aligned");
+
+ASSERT(__sheap % 4 == 0, "
+BUG(cortex-m-rt): start of .heap is not 4-byte aligned");
+
+/* # Position checks */
+
+/* ## .vector_table */
+ASSERT(__reset_vector == ADDR(.vector_table) + 0x8, "
+BUG(cortex-m-rt): the reset vector is missing");
+
+ASSERT(__eexceptions == ADDR(.vector_table) + 0x40, "
+BUG(cortex-m-rt): the exception vectors are missing");
+
+ASSERT(SIZEOF(.vector_table) > 0x40, "
+ERROR(cortex-m-rt): The interrupt vectors are missing.
+Possible solutions, from most likely to less likely:
+- Link to a svd2rust generated device crate
 - Disable the 'device' feature of cortex-m-rt to build a generic application (a dependency
-  may be enabling it)
+may be enabling it)
 - Supply the interrupt handlers yourself. Check the documentation for details.");
 
-ASSERT(__einterrupts <= _stext, "
-cortex-m-rt: The '.text' section can't be placed inside the '.vector_table' section. Set
-'_stext' to an address greater than '__einterrupts' (cf. `nm` output)");
+/* ## .text */
+ASSERT(ADDR(.vector_table) + SIZEOF(.vector_table) <= _stext, "
+ERROR(cortex-m-rt): The .text section can't be placed inside the .vector_table section
+Set _stext to an address greater than the end of .vector_table (See output of `nm`)");
 
-ASSERT(_stext < ORIGIN(FLASH) + LENGTH(FLASH), "
-cortex-m-rt The '.text' section must be placed inside the FLASH memory. Set '_stext' to an
-address smaller than 'ORIGIN(FLASH) + LENGTH(FLASH)");
+ASSERT(_stext + SIZEOF(.text) < ORIGIN(FLASH) + LENGTH(FLASH), "
+ERROR(cortex-m-rt): The .text section must be placed inside the FLASH memory.
+Set _stext to an address smaller than 'ORIGIN(FLASH) + LENGTH(FLASH)'");
 
-/* This has been temporarily omitted because it's not supported by LLD */
-/* ASSERT(__sbss % 4 == 0 && __ebss % 4 == 0, " */
-/* .bss is not 4-byte aligned at its boundaries. This is a cortex-m-rt bug."); */
-
-/* ASSERT(__sdata % 4 == 0 && __edata % 4 == 0, " */
-/* .data is not 4-byte aligned at its boundaries. This is a cortex-m-rt bug."); */
-
-/* ASSERT(__sidata % 4 == 0, " */
-/* __sidata is not 4-byte aligned. This is a cortex-m-rt bug."); */
-
-ASSERT(__sgot == __egot, "
-.got section detected in the input object files. Dynamic relocations are not supported.
-If you are linking to C code compiled using the `cc` crate then modify your build script
-to compile the C code _without_ the -fPIC flag. See the documentation of the
-`cc::Build.pic` method for details.");
+/* # Other checks */
+ASSERT(SIZEOF(.got) == 0, "
+ERROR(cortex-m-rt): .got section detected in the input object files
+Dynamic relocations are not supported. If you are linking to C code compiled using
+the 'cc' crate then modify your build script to compile the C code _without_
+the -fPIC flag. See the documentation of the `cc::Build.pic` method for details.");
 /* Do not exceed this mark in the error messages above                                    | */


### PR DESCRIPTION
to make it more compatible with LLD. This commit contains no functional changes.

fixes #70

Overview of changes:

- Alignment checks are enabled now that rust-lld (LLD 7.0) supports the modulo
operator.

- Removed some private symbols (e.g. __foo) in favor of ADDR and SIZEOF.

- Turned .got into a NOLOAD section now that rust-lld supports it.

- Replaced `ABSOLUTE(.)` with `.` as an old LLD overlap bug seems to be gone and
ABSOLUTE seems to cause problems, like #70, on bigger programs.

- Made the linker assertion messages more uniform.

- Extended test suite to check that linking works with both rust-lld and GNU
LD.

r? therealprof (chosen at random)