### PR TITLE
[WIP] provide defaults for DefaultHandler and HardFault

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -45,6 +45,9 @@ PROVIDE(DebugMonitor = DefaultHandler);
 PROVIDE(PendSV = DefaultHandler);
 PROVIDE(SysTick = DefaultHandler);
 
+PROVIDE(DefaultHandler = DefaultDefaultHandler);
+PROVIDE(UserHardFault = DefaultUserHardFault);
+
 /* # Interrupt vectors */
 EXTERN(__INTERRUPTS); /* `static` variable similar to `__EXCEPTIONS` */
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@
 
 extern crate r0;
 
-use core::fmt;
+use core::{fmt, ptr};
 
 /// Registers stacked (pushed into the stack) during an exception
 #[derive(Clone, Copy)]
@@ -508,6 +508,26 @@ pub unsafe extern "C" fn Reset() -> ! {
 
             trampoline()
         }
+    }
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub unsafe extern "C" fn DefaultDefaultHandler() {
+    loop {
+        // add some side effect to prevent this from turning into a UDF instruction
+        // see rust-lang/rust#28728
+        ptr::read_volatile(&0u8);
+    }
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub unsafe extern "C" fn DefaultUserHardFault() {
+    loop {
+        // add some side effect to prevent this from turning into a UDF instruction
+        // see rust-lang/rust#28728
+        ptr::read_volatile(&0u8);
     }
 }
 


### PR DESCRIPTION
`exception!(HardFault, ..)` and `exception!(*, ..)` can now be omitted from
programs to pick up the default behavior of an infinite loop. Existing programs
that define these exception handlers will continue to work w/o any functional
change.

closes #72

--

Annoyances:

- The handlers can't be *just* an infinite loop because of rust-lang/rust#28728.
If we define the handlers as just `loop {}` they will become an abort (UDF)
instruction. And that would turn HardFault into infinite recursion. For that
reason I have made them into an infinite loop that does some side effect

- If you stick to the defaults then the symbol name of the default handler
changes from `DefaultHandler` (override) to `DefaultDefaultHandler` (default).
We can make these two names more similar but I think we can not prevent the
rename. Something similar happens with UserHardFault (which becomes
DefaultUserHardFault when not overridden).

cc @rust-embedded/cortex-m