### PR TITLE
Update linker script to put .data into FLASH

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -11,6 +11,9 @@ main() {
         main
         state
     )
+    local fail_examples=(
+        data_overflow
+    )
     if [ $TRAVIS_RUST_VERSION = nightly ]; then
         # linking with GNU LD
         for ex in "${examples[@]}"; do
@@ -19,6 +22,15 @@ main() {
                   -C link-arg=-Wl,-Tlink.x
 
             cargo rustc --target $TARGET --example $ex --release -- \
+                  -C link-arg=-nostartfiles \
+                  -C link-arg=-Wl,-Tlink.x
+        done
+        for ex in "${fail_examples[@]}"; do
+            ! cargo rustc --target $TARGET --example $ex -- \
+                  -C link-arg=-nostartfiles \
+                  -C link-arg=-Wl,-Tlink.x
+
+            ! cargo rustc --target $TARGET --example $ex --release -- \
                   -C link-arg=-nostartfiles \
                   -C link-arg=-Wl,-Tlink.x
         done
@@ -39,6 +51,17 @@ main() {
                   -C link-arg=-Tlink.x
 
             cargo rustc --target $TARGET --example $ex --release -- \
+                  -C linker=rust-lld \
+                  -Z linker-flavor=ld.lld \
+                  -C link-arg=-Tlink.x
+        done
+        for ex in "${fail_examples[@]}"; do
+            ! cargo rustc --target $TARGET --example $ex -- \
+                  -C linker=rust-lld \
+                  -Z linker-flavor=ld.lld \
+                  -C link-arg=-Tlink.x
+
+            ! cargo rustc --target $TARGET --example $ex --release -- \
                   -C linker=rust-lld \
                   -Z linker-flavor=ld.lld \
                   -C link-arg=-Tlink.x

--- a/examples/data_overflow.rs
+++ b/examples/data_overflow.rs
@@ -1,0 +1,42 @@
+//! This is not an example; this is a linker overflow detection test
+//! which should fail to link due to .data overflowing FLASH.
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+#[macro_use(entry, exception)]
+extern crate cortex_m_rt as rt;
+extern crate panic_abort;
+
+use core::ptr;
+
+use rt::ExceptionFrame;
+
+entry!(main);
+
+// This large static array uses most of .rodata
+static RODATA: [u8; 48*1024] = [1u8; 48*1024];
+
+// This large mutable array causes .data to use the rest of FLASH
+// without also overflowing RAM.
+static mut DATA: [u8; 16*1024] = [1u8; 16*1024];
+
+fn main() -> ! {
+    unsafe {
+        let _bigdata = ptr::read_volatile(&RODATA as *const u8);
+        let _bigdata = ptr::read_volatile(&DATA as *const u8);
+    }
+
+    loop {}
+}
+
+exception!(HardFault, hard_fault);
+
+fn hard_fault(_ef: &ExceptionFrame) -> ! {
+    loop {}
+}
+
+exception!(*, default_handler);
+
+fn default_handler(_irqn: i16) {}

--- a/examples/data_overflow.rs
+++ b/examples/data_overflow.rs
@@ -5,13 +5,11 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry, exception)]
+#[macro_use(entry)]
 extern crate cortex_m_rt as rt;
 extern crate panic_abort;
 
 use core::ptr;
-
-use rt::ExceptionFrame;
 
 entry!(main);
 
@@ -30,13 +28,3 @@ fn main() -> ! {
 
     loop {}
 }
-
-exception!(HardFault, hard_fault);
-
-fn hard_fault(_ef: &ExceptionFrame) -> ! {
-    loop {}
-}
-
-exception!(*, default_handler);
-
-fn default_handler(_irqn: i16) {}

--- a/link.x.in
+++ b/link.x.in
@@ -84,24 +84,24 @@ SECTIONS
   } > FLASH
 
   /* ### .rodata */
-  .rodata :
+  .rodata : ALIGN(4)
   {
     *(.rodata .rodata.*);
 
-    /* 4-byte align the end (VMA) of this section */
-    /* WHY? To my knowledge there's no way to indicate the alignment of *LMA* so we align *this*
-    section with the goal of using its end address as the LMA of .data */
+    /* 4-byte align the end (VMA) of this section.
+       This is required by LLD to ensure the LMA of the following .data
+       section will have the correct alignment. */
     . = ALIGN(4);
   } > FLASH
 
   /* ## Sections in RAM */
   /* ### .data */
-  .data : AT(ADDR(.rodata) + SIZEOF(.rodata)) /* LMA */
+  .data : ALIGN(4)
   {
     *(.data .data.*);
 
     . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
-  } > RAM
+  } > RAM AT > FLASH
 
   /* VMA of .data */
   __sdata = ADDR(.data);
@@ -111,7 +111,7 @@ SECTIONS
   __sidata = LOADADDR(.data);
 
   /* ### .bss */
-  .bss :
+  .bss : ALIGN(4)
   {
     *(.bss .bss.*);
 

--- a/memory.x
+++ b/memory.x
@@ -1,8 +1,12 @@
 /* Device specific memory layout */
 
+/* This file is used to build the cortex-m-rt examples,
+   but not other applications using cortex-m-rt. */
+
 MEMORY
 {
   /* FLASH and RAM are mandatory memory regions */
+  /* Update examples/data_overflow.rs if you change these sizes. */
   FLASH : ORIGIN = 0x08000000, LENGTH = 64K
   RAM : ORIGIN = 0x20000000, LENGTH = 20K
 


### PR DESCRIPTION
This is the updated linker script and test from #86.

Sadly it looks like LLD does not use the `ALIGN(4)` in the `.data` section header to align the LMA (unlike gcc), so we still need the `. = ALIGN(4)` at the end of `.rodata` to ensure LMA alignment.

I've added a failing example which the ci script ensures fails when `.data` causes overflow. It just checks for non-zero return from cargo rather than specifically grepping for the linker error messages about `.data` overflowing; since we only have the one failing example I could remove the loop and just specifically check it and grep for the relevant error from gcc and lld if people think that would be better.