### PR TITLE
Add additional meta data to improve crate experience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Jorge Aparicio <jorge@japaric.io>"]
 categories = ["embedded", "no-std"]
 description = "Minimal runtime / startup for Cortex-M microcontrollers"
 documentation = "https://docs.rs/cortex-m-rt"
+readme = "README.md"
 keywords = ["arm", "cortex-m", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"


### PR DESCRIPTION
* Add readme setting, so README.md is shown on https://crates.io/