### PR TITLE
reduce the size of default handlers

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -45,8 +45,8 @@ PROVIDE(DebugMonitor = DefaultHandler);
 PROVIDE(PendSV = DefaultHandler);
 PROVIDE(SysTick = DefaultHandler);
 
-PROVIDE(DefaultHandler = DefaultDefaultHandler);
-PROVIDE(UserHardFault = DefaultUserHardFault);
+PROVIDE(DefaultHandler = EndlessLoop);
+PROVIDE(UserHardFault = EndlessLoop);
 
 /* # Interrupt vectors */
 EXTERN(__INTERRUPTS); /* `static` variable similar to `__EXCEPTIONS` */

--- a/link.x.in
+++ b/link.x.in
@@ -45,8 +45,8 @@ PROVIDE(DebugMonitor = DefaultHandler);
 PROVIDE(PendSV = DefaultHandler);
 PROVIDE(SysTick = DefaultHandler);
 
-PROVIDE(DefaultHandler = EndlessLoop);
-PROVIDE(UserHardFault = EndlessLoop);
+PROVIDE(DefaultHandler = DefaultHandler_);
+PROVIDE(UserHardFault = UserHardFault_);
 
 /* # Interrupt vectors */
 EXTERN(__INTERRUPTS); /* `static` variable similar to `__EXCEPTIONS` */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,8 @@
 
 extern crate r0;
 
-use core::{fmt, ptr};
+use core::fmt;
+use core::sync::atomic::{self, Ordering};
 
 /// Registers stacked (pushed into the stack) during an exception
 #[derive(Clone, Copy)]
@@ -531,21 +532,11 @@ pub unsafe extern "C" fn Reset() -> ! {
 
 #[doc(hidden)]
 #[no_mangle]
-pub unsafe extern "C" fn DefaultDefaultHandler() {
+pub unsafe extern "C" fn EndlessLoop() -> ! {
     loop {
         // add some side effect to prevent this from turning into a UDF instruction
-        // see rust-lang/rust#28728
-        ptr::read_volatile(&0u8);
-    }
-}
-
-#[doc(hidden)]
-#[no_mangle]
-pub unsafe extern "C" fn DefaultUserHardFault() {
-    loop {
-        // add some side effect to prevent this from turning into a UDF instruction
-        // see rust-lang/rust#28728
-        ptr::read_volatile(&0u8);
+        // see rust-lang/rust#28728 for details
+        atomic::compiler_fence(Ordering::SeqCst);
     }
 }
 
@@ -924,5 +915,5 @@ macro_rules! pre_init {
             let f: unsafe fn() = $handler;
             f();
         }
-    }
+    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,9 +530,20 @@ pub unsafe extern "C" fn Reset() -> ! {
     }
 }
 
+#[allow(unused_variables)]
 #[doc(hidden)]
 #[no_mangle]
-pub unsafe extern "C" fn EndlessLoop() -> ! {
+pub unsafe extern "C" fn UserHardFault_(ef: &ExceptionFrame) -> ! {
+    loop {
+        // add some side effect to prevent this from turning into a UDF instruction
+        // see rust-lang/rust#28728 for details
+        atomic::compiler_fence(Ordering::SeqCst);
+    }
+}
+
+#[doc(hidden)]
+#[no_mangle]
+pub unsafe extern "C" fn DefaultHandler_() -> ! {
     loop {
         // add some side effect to prevent this from turning into a UDF instruction
         // see rust-lang/rust#28728 for details


### PR DESCRIPTION
this commit replaces the two default handler (DefaultDefaultHandler and
DefaultUserHardFault) by a single handler named `EndlessLoop`. This results in
one less symbol being generated.

Also this new handler uses `compiler_fence` to avoid the "infinite loops w/o
side effects are undef values" bug in LLVM. `compiler_fence` is guaranteed to
generate no code so this reduces the size of the handler (when compiler in
release).

---

As far as I could test this new handler doesn't generate abort instructions when
optimized so it seems like a safe replacement. If we are feeling paranoid then
once #95 we could implement EndlessLoop in assembly.

r? @rust-embedded/cortex-m (anyone)