### PR TITLE
[RFC] `#[ramfunc]`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.rs.bk
+.#*
 Cargo.lock
 bin/*.after
 bin/*.before

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.5.3"
 
 [dependencies]
 r0 = "0.2.1"
+cortex-m-rt-macros = { path = "macros", version = "0.1.0" }
 
 [dev-dependencies]
 panic-semihosting = "0.3.0"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,6 +5,8 @@ main() {
 
     cargo check --target $TARGET --features device
 
+    ( cd macros && cargo check && cargo test )
+
     local examples=(
         alignment
         minimal

--- a/examples/alignment.rs
+++ b/examples/alignment.rs
@@ -4,13 +4,12 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry)]
 extern crate cortex_m_rt as rt;
 extern crate panic_abort;
 
 use core::ptr;
 
-entry!(main);
+use rt::entry;
 
 static mut BSS1: u16 = 0;
 static mut BSS2: u8 = 0;
@@ -19,6 +18,7 @@ static mut DATA2: u16 = 1;
 static RODATA1: &[u8; 3] = b"012";
 static RODATA2: &[u8; 2] = b"34";
 
+#[entry]
 fn main() -> ! {
     unsafe {
         let _bss1 = ptr::read_volatile(&BSS1);

--- a/examples/data_overflow.rs
+++ b/examples/data_overflow.rs
@@ -5,13 +5,12 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry)]
 extern crate cortex_m_rt as rt;
 extern crate panic_abort;
 
 use core::ptr;
 
-entry!(main);
+use rt::entry;
 
 // This large static array uses most of .rodata
 static RODATA: [u8; 48*1024] = [1u8; 48*1024];
@@ -20,6 +19,7 @@ static RODATA: [u8; 48*1024] = [1u8; 48*1024];
 // without also overflowing RAM.
 static mut DATA: [u8; 16*1024] = [1u8; 16*1024];
 
+#[entry]
 fn main() -> ! {
     unsafe {
         let _bigdata = ptr::read_volatile(&RODATA as *const u8);

--- a/examples/device.rs
+++ b/examples/device.rs
@@ -5,13 +5,12 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry)]
 extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 
-// the program entry point
-entry!(main);
+use rt::entry;
 
+#[entry]
 fn main() -> ! {
     loop {}
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -5,13 +5,13 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry)]
 extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 
-// the program entry point
-entry!(main);
+use rt::entry;
 
+// the program entry point
+#[entry]
 fn main() -> ! {
     loop {}
 }

--- a/examples/override-exception.rs
+++ b/examples/override-exception.rs
@@ -6,28 +6,23 @@
 #![no_std]
 
 extern crate cortex_m;
-#[macro_use(entry, exception)]
 extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 
 use cortex_m::asm;
-use rt::ExceptionFrame;
+use rt::{entry, exception, ExceptionFrame};
 
-// the program entry point
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     loop {}
 }
 
-exception!(*, default_handler);
-
+#[exception(DefaultHandler)]
 fn default_handler(_irqn: i16) {
     asm::bkpt();
 }
 
-exception!(HardFault, hard_fault);
-
+#[exception(HardFault)]
 fn hard_fault(_ef: &ExceptionFrame) -> ! {
     asm::bkpt();
 

--- a/examples/pre_init.rs
+++ b/examples/pre_init.rs
@@ -4,19 +4,17 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry, pre_init)]
 extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 
-pre_init!(disable_watchdog);
+use rt::{entry, pre_init};
 
+#[pre_init]
 unsafe fn disable_watchdog() {
     // Do what you need to disable the watchdog.
 }
 
-// the program entry point
-entry!(main);
-
+#[entry]
 fn main() -> ! {
     loop {}
 }

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -5,20 +5,18 @@
 #![no_main]
 #![no_std]
 
-#[macro_use(entry, exception)]
 extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 
-// the program entry point
-entry!(main);
+use rt::{entry, exception};
 
+#[entry]
 fn main() -> ! {
     loop {}
 }
 
 // exception handler with state
-exception!(SysTick, sys_tick, state: u32 = 0);
-
-fn sys_tick(state: &mut u32) {
-    *state += 1;
+#[exception(SysTick, static STATE: u32 = 0)]
+fn sys_tick() {
+    *STATE += 1;
 }

--- a/link.x.in
+++ b/link.x.in
@@ -115,6 +115,20 @@ SECTIONS
   /* LMA of .data */
   __sidata = LOADADDR(.data);
 
+  .ramfunc : ALIGN(4)
+  {
+    *(.ramfunc.*);
+
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+  } > RAM AT > FLASH
+
+  /* VMA of .ramfunc */
+  __sramfunc = ADDR(.ramfunc);
+  __eramfunc = ADDR(.ramfunc) + SIZEOF(.ramfunc);
+
+  /* LMA of .ramfunc */
+  __siramfunc = LOADADDR(.ramfunc);
+
   /* ### .bss */
   .bss : ALIGN(4)
   {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cortex-m-rt-macros"
+version = "0.1.0"
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "0.6.6"
+
+[dependencies.syn]
+features = ["extra-traits", "full"]
+version = "0.14.8"
+
+[dev-dependencies]
+cortex-m-rt = { path = ".." }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -8,6 +8,7 @@ proc-macro = true
 
 [dependencies]
 quote = "0.6.6"
+rand = "0.5.5"
 
 [dependencies.syn]
 features = ["extra-traits", "full"]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,462 @@
+#![deny(warnings)]
+
+extern crate proc_macro;
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+
+use syn::synom::Synom;
+use syn::token::{Colon, Comma, Eq, Static};
+use syn::{Expr, FnArg, Ident, ItemFn, ReturnType, Type, Visibility};
+
+use proc_macro::TokenStream;
+
+/// Attribute to declare the entry point of the program
+///
+/// **NOTE** This macro must be invoked once and must be invoked from an accessible module, ideally
+/// from the root of the crate.
+///
+/// The specified function will be called by the reset handler *after* RAM has been initialized. In
+/// the case of the `thumbv7em-none-eabihf` target the FPU will also be enabled before the function
+/// is called.
+///
+/// The type of the specified function must be `fn() -> !` (never ending function)
+///
+/// # Examples
+///
+/// ``` no_run
+/// # #![no_main]
+/// # use cortex_m_rt_macros::entry;
+/// #[entry]
+/// fn main() -> ! {
+///     loop {
+///         /* .. */
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
+    let f: ItemFn = syn::parse(input).expect("`#[entry]` must be applied to a function");
+
+    // check the function signature
+    assert!(
+        f.constness.is_none()
+            && f.vis == Visibility::Inherited
+            && f.unsafety.is_none()
+            && f.abi.is_none()
+            && f.decl.inputs.is_empty()
+            && f.decl.generics.params.is_empty()
+            && f.decl.generics.where_clause.is_none()
+            && f.decl.variadic.is_none()
+            && match f.decl.output {
+                ReturnType::Default => false,
+                ReturnType::Type(_, ref ty) => match **ty {
+                    Type::Never(_) => true,
+                    _ => false,
+                },
+            },
+        "`#[entry]` function must have signature `fn() -> !`"
+    );
+
+    assert_eq!(
+        args.to_string(),
+        "",
+        "`entry` attribute must have no arguments"
+    );
+
+    // XXX should we blacklist other attributes?
+    let attrs = f.attrs;
+    let ident = f.ident;
+    let block = f.block;
+
+    quote!(
+        #[export_name = "main"]
+        #(#attrs)*
+        pub fn #ident() -> ! #block
+    ).into()
+}
+
+struct ExceptionArgs {
+    first: Ident,
+    second: Option<State>,
+}
+
+impl Synom for ExceptionArgs {
+    named!(parse -> Self, do_parse!(
+        first: syn!(Ident) >>
+            second: option!(syn!(State)) >> (
+                ExceptionArgs { first, second }
+            )
+    ));
+}
+
+struct State {
+    _comma: Comma,
+    _static: Static,
+    ident: Ident,
+    _colon: Colon,
+    ty: Type,
+    _eq: Eq,
+    expr: Expr,
+}
+
+impl Synom for State {
+    named!(parse -> Self, do_parse!(
+        _comma: punct!(,) >>
+            _static: syn!(Static) >>
+            ident: syn!(Ident) >>
+            _colon: punct!(:) >>
+            ty: syn!(Type) >>
+            _eq: punct!(=) >>
+            expr: syn!(Expr) >> (
+                State { _comma, _static, ident, _colon, ty, _eq, expr }
+            )
+    ));
+}
+
+/// Attribute to declare an exception handler
+///
+/// **NOTE** This macro must be invoked from an accessible module, ideally from the root of the
+/// crate.
+///
+/// # Syntax
+///
+/// ```
+/// # use cortex_m_rt_macros::exception;
+/// #[exception(SysTick, static COUNT: u32 = 0)]
+/// fn handler() {
+///     // ..
+/// }
+///
+/// # fn main() {}
+/// ```
+///
+/// where the first argument can be one of:
+///
+/// - `DefaultHandler`
+/// - `NonMaskableInt`
+/// - `HardFault`
+/// - `MemoryManagement` (a)
+/// - `BusFault` (a)
+/// - `UsageFault` (a)
+/// - `SecureFault` (b)
+/// - `SVCall`
+/// - `DebugMonitor` (a)
+/// - `PendSV`
+/// - `SysTick`
+///
+/// and the second is optional.
+///
+/// (a) Not available on Cortex-M0 variants (`thumbv6m-none-eabi`)
+///
+/// (b) Only available on ARMv8-M
+///
+/// # Usage
+///
+/// `#[exception(HardFault)]` sets the hard fault handler. The handler must have signature
+/// `fn(&ExceptionFrame) -> !`. This handler is not allowed to return as that can cause undefined
+/// behavior.
+///
+/// `#[exception(DefaultHandler)]` sets the *default* handler. All exceptions which have not been
+/// assigned a handler will be serviced by this handler. This handler must have signature `fn(irqn:
+/// i16)`. `irqn` is the IRQ number (See CMSIS); `irqn` will be a negative number when the handler
+/// is servicing a core exception; `irqn` will be a positive number when the handler is servicing a
+/// device specific exception (interrupt).
+///
+/// `#[exception(Name)]` overrides the default handler for the exception with the given `Name`.
+///
+/// # Examples
+///
+/// - Setting the `HardFault` handler
+///
+/// ```
+/// # extern crate cortex_m_rt;
+/// # extern crate cortex_m_rt_macros;
+/// # use cortex_m_rt_macros::exception;
+/// #[exception(HardFault)]
+/// fn hard_fault(ef: &cortex_m_rt::ExceptionFrame) -> ! {
+///     // prints the exception frame as a panic message
+///     panic!("{:#?}", ef);
+/// }
+///
+/// # fn main() {}
+/// ```
+///
+/// - Setting the default handler
+///
+/// ```
+/// # use cortex_m_rt_macros::exception;
+/// #[exception(DefaultHandler)]
+/// fn default_handler(irqn: i16) {
+///     println!("IRQn = {}", irqn);
+/// }
+///
+/// # fn main() {}
+/// ```
+///
+/// - Overriding the `SysTick` handler
+///
+/// ```
+/// extern crate cortex_m_rt as rt;
+///
+/// use rt::exception;
+///
+/// #[exception(SysTick, static COUNT: i32 = 0)]
+/// fn sys_tick() {
+///     *COUNT += 1;
+///
+///     println!("{}", COUNT);
+/// }
+///
+/// # fn main() {}
+/// ```
+#[proc_macro_attribute]
+pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
+    let f: ItemFn = syn::parse(input).expect("`#[exception]` must be applied to a function");
+    let args: ExceptionArgs = syn::parse(args).expect(
+        "`exception` attribute expects the exception name as its argument. \
+         e.g. `#[exception(HardFault)]`",
+    );
+    let name = args.first;
+    let name_s = name.to_string();
+
+    enum Exception {
+        DefaultHandler,
+        HardFault,
+        Other,
+    }
+
+    // first validation of the exception name
+    let exn = match &*name_s {
+        "DefaultHandler" => Exception::DefaultHandler,
+        "HardFault" => Exception::HardFault,
+        // NOTE that at this point we don't check if the exception is available on the target (e.g.
+        // MemoryManagement is not available on Cortex-M0)
+        "NonMaskableInt" | "MemoryManagement" | "BusFault" | "UsageFault" | "SecureFault"
+        | "SVCall" | "DebugMonitor" | "PendSV" | "SysTick" => Exception::Other,
+        _ => panic!("{} is not a valid exception name", name_s),
+    };
+
+    // XXX should we blacklist other attributes?
+    let attrs = f.attrs;
+    let ident = f.ident;
+    let block = f.block;
+    let stmts = &block.stmts;
+
+    match exn {
+        Exception::DefaultHandler => {
+            assert!(
+                f.constness.is_none()
+                    && f.vis == Visibility::Inherited
+                    && f.unsafety.is_none()
+                    && f.abi.is_none()
+                    && f.decl.inputs.len() == 1
+                    && f.decl.generics.params.is_empty()
+                    && f.decl.generics.where_clause.is_none()
+                    && f.decl.variadic.is_none()
+                    && match f.decl.output {
+                        ReturnType::Default => true,
+                        ReturnType::Type(_, ref ty) => match **ty {
+                            Type::Tuple(ref tuple) => tuple.elems.is_empty(),
+                            _ => false,
+                        },
+                    },
+                "`#[exception(DefaultHandler)]` function must have signature `fn(i16)`"
+            );
+
+            assert!(
+                args.second.is_none(),
+                "`#[exception(DefaultHandler)]` takes no additional arguments"
+            );
+
+            let arg = match f.decl.inputs[0] {
+                FnArg::Captured(ref arg) => arg,
+                _ => unreachable!(),
+            };
+
+            quote!(
+                #[export_name = #name_s]
+                #(#attrs)*
+                pub fn #ident() {
+                    extern crate core;
+
+                    const SCB_ICSR: *const u32 = 0xE000_ED04 as *const u32;
+
+                    let #arg = unsafe { core::ptr::read(SCB_ICSR) as u8 as i16 - 16 };
+
+                    #(#stmts)*
+                }
+            ).into()
+        }
+        Exception::HardFault => {
+            assert!(
+                f.constness.is_none()
+                    && f.vis == Visibility::Inherited
+                    && f.unsafety.is_none()
+                    && f.abi.is_none()
+                    && f.decl.inputs.len() == 1
+                    && match f.decl.inputs[0] {
+                        FnArg::Captured(ref arg) => match arg.ty {
+                            Type::Reference(ref r) => {
+                                r.lifetime.is_none() && r.mutability.is_none()
+                            }
+                            _ => false,
+                        },
+                        _ => false,
+                    }
+                    && f.decl.generics.params.is_empty()
+                    && f.decl.generics.where_clause.is_none()
+                    && f.decl.variadic.is_none()
+                    && match f.decl.output {
+                        ReturnType::Default => false,
+                        ReturnType::Type(_, ref ty) => match **ty {
+                            Type::Never(_) => true,
+                            _ => false,
+                        },
+                    },
+                "`#[exception(HardFault)]` function must have signature `fn(&ExceptionFrame) -> !`"
+            );
+
+            assert!(
+                args.second.is_none(),
+                "`#[exception(HardFault)]` takes no additional arguments"
+            );
+
+            let arg = match f.decl.inputs[0] {
+                FnArg::Captured(ref arg) => arg,
+                _ => unreachable!(),
+            };
+
+            let pat = &arg.pat;
+
+            quote!(
+                #[export_name = "UserHardFault"]
+                #(#attrs)*
+                pub unsafe extern "C" fn #ident(#arg) -> ! {
+                    extern crate cortex_m_rt;
+
+                    // further type check of the input argument
+                    let #pat: &cortex_m_rt::ExceptionFrame = #pat;
+
+                    #(#stmts)*
+                }
+            ).into()
+        }
+        Exception::Other => {
+            assert!(
+                f.constness.is_none()
+                    && f.vis == Visibility::Inherited
+                    && f.unsafety.is_none()
+                    && f.abi.is_none()
+                    && f.decl.inputs.is_empty()
+                    && f.decl.generics.params.is_empty()
+                    && f.decl.generics.where_clause.is_none()
+                    && f.decl.variadic.is_none()
+                    && match f.decl.output {
+                        ReturnType::Default => true,
+                        ReturnType::Type(_, ref ty) => match **ty {
+                            Type::Tuple(ref tuple) => tuple.elems.is_empty(),
+                            _ => false,
+                        },
+                    },
+                "`#[exception]` functions must have signature `fn()`"
+            );
+
+            if let Some(second) = args.second {
+                let ty = second.ty;
+                let expr = second.expr;
+                let state = second.ident;
+
+                quote!(
+                    #[export_name = #name_s]
+                    #(#attrs)*
+                    pub fn #ident() {
+                        extern crate cortex_m_rt;
+
+                        cortex_m_rt::Exception::#name;
+
+                        static mut __STATE__: #ty = #expr;
+
+                        #[allow(non_snake_case)]
+                        let #state: &mut #ty = unsafe { &mut __STATE__ };
+
+                        #(#stmts)*
+                    }
+                ).into()
+            } else {
+                quote!(
+                    #[export_name = #name_s]
+                    #(#attrs)*
+                    pub fn #ident() {
+                        extern crate cortex_m_rt;
+
+                        cortex_m_rt::Exception::#name;
+
+                        #(#stmts)*
+                    }
+                ).into()
+            }
+        }
+    }
+}
+
+/// Attribute to mark which function will be called at the beginning of the reset handler.
+///
+/// The function must have the signature of `unsafe fn()`.
+///
+/// The function passed will be called before static variables are initialized. Any access of static
+/// variables will result in undefined behavior.
+///
+/// # Examples
+///
+/// ```
+/// # use cortex_m_rt_macros::pre_init;
+/// #[pre_init]
+/// unsafe fn before_main() {
+///     // do something here
+/// }
+///
+/// # fn main() {}
+/// ```
+#[proc_macro_attribute]
+pub fn pre_init(args: TokenStream, input: TokenStream) -> TokenStream {
+    let f: ItemFn = syn::parse(input).expect("`#[pre_init]` must be applied to a function");
+
+    // check the function signature
+    assert!(
+        f.constness.is_none()
+            && f.vis == Visibility::Inherited
+            && f.unsafety.is_some()
+            && f.abi.is_none()
+            && f.decl.inputs.is_empty()
+            && f.decl.generics.params.is_empty()
+            && f.decl.generics.where_clause.is_none()
+            && f.decl.variadic.is_none()
+            && match f.decl.output {
+                ReturnType::Default => true,
+                ReturnType::Type(_, ref ty) => match **ty {
+                    Type::Tuple(ref tuple) => tuple.elems.is_empty(),
+                    _ => false,
+                },
+            },
+        "`#[pre_init]` function must have signature `unsafe fn()`"
+    );
+
+    assert_eq!(
+        args.to_string(),
+        "",
+        "`pre_init` attribute must have no arguments"
+    );
+
+    // XXX should we blacklist other attributes?
+    let attrs = f.attrs;
+    let ident = f.ident;
+    let block = f.block;
+
+    quote!(
+        #[export_name = "__pre_init"]
+        #(#attrs)*
+        pub unsafe fn #ident() #block
+    ).into()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,7 +387,7 @@ extern crate r0;
 use core::fmt;
 use core::sync::atomic::{self, Ordering};
 
-pub use macros::{entry, exception, pre_init};
+pub use macros::{entry, exception, pre_init, ramfunc};
 
 /// Registers stacked (pushed into the stack) during an exception
 #[derive(Clone, Copy)]
@@ -470,6 +470,9 @@ pub unsafe extern "C" fn Reset() -> ! {
         static mut __edata: u32;
         static __sidata: u32;
 
+        static mut __sramfunc: u32;
+        static mut __eramfunc: u32;
+        static __siramfunc: u32;
     }
 
     extern "Rust" {
@@ -484,7 +487,9 @@ pub unsafe extern "C" fn Reset() -> ! {
 
     // Initialize RAM
     r0::zero_bss(&mut __sbss, &mut __ebss);
+    // XXX is there a reliable way to do a single `init_data` to initialize both .data and .ramfunc
     r0::init_data(&mut __sdata, &mut __edata, &__sidata);
+    r0::init_data(&mut __sramfunc, &mut __eramfunc, &__siramfunc);
 
     match () {
         #[cfg(not(has_fpu))]


### PR DESCRIPTION
This is a 2 in 1 RFC and implementation PR. This builds on top of #90 so you can ignore the first commit. See #42 for some background information.

@rust-embedded/cortex-m Please review this RFC and if you are in favor approve this PR.

---

# Summary

Add a `#[ramfunc]` attribute to this crate. This attribute can be applied to
functions to place them in RAM.

# Motivation

Running functions from RAM may result in faster execution times. Thus placing
"hot code" in RAM may improve the performance of an application.

# Design and rationale

## Expansion

The `#[ramfunc]` attribute will expand into a `#[link_section = ..]`
attribute that will place the function in a `.ramfunc.$hash` section. Each
`#[ramfunc]` function will be placed in a *different* linker section (in a
similar fashion to `-ffunction-sections`) to let the linker GC (Garbage Collect)
the unused functions . To this end, `#[ramfunc]` won't accept generic functions
because if the generic function has several instantiations all of them would end
in the same linker section.

`link.x` will be tweaked to instruct the linker to collect all the input
sections of the form `.ramfunc.*` into a single `.ramfunc` output section that
will placed in RAM.

The `Reset` handler will be updated to initialize the `.ramfunc` section before
the user entry point is called.

## Why an attribute?

This is implemented as an attribute to make it composable with the attributes to
be added in RFC #90. For example you can place an exception handler in RAM. The
compiler won't generate a [veener] in this case as the address to the RAM location
will be placed in the vector table.

[veener]: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0474i/CHDBDFBH.html

``` rust
#[exception(SysTick)]
#[ramfunc]
fn systick() {
    // do stuff
}
```

## Why a separate linker section?

Using a separate section lets the compiler / linker assign the right ELF flags
to .ramfunc (i.e. "AX"). That way `.ramfunc` ends up showing in the output of
`objdump -C`.

``` console
$ readelf -S app
  [ 1] .vector_table     PROGBITS        08000000 010000 000400 00   A  0   0  4
  [ 2] .text             PROGBITS        08000400 010400 0003ea 00  AX  0   0  2
  [ 3] .rodata           PROGBITS        080007ec 020020 000000 00  WA  0   0  4
  [ 4] .data             PROGBITS        20000000 020000 000004 00  WA  0   0  4
  [ 5] .ramfunc          PROGBITS        20000004 020004 00001c 00  AX  0   0  4
  [ 6] .bss              NOBITS          20000020 000000 000000 00  WA  0   0  4
```

``` console
$ arm-none-eabi-objdump -Cd app
Disassembly of section .text:

08000400 <Reset>:
 8000400:       f000 f9ee       bl      80007e0 <DefaultPreInit>
 (..)

Disassembly of section .ramfunc:

20000004 <SysTick>:
20000004:       b580            push    {r7, lr}
(..)
```

This also means that `.data` would only contain ... data so the section can be
inspected (not disassembled) separately.

``` console
$ arm-none-eabi-objdump -s -j .data app
Contents of section .data:
 20000000 01000000                             ....
```

The downside (?) is that the default format of `size` will report `.ramfunc`
under text.

``` console
$ size app
   text    data     bss     dec     hex filename
   2066       4       4    2074     81a app
```

But in any case it's (usually) better to look at the output in System V format.

``` console
$ size -Ax app
app  :
section             size         addr
.vector_table      0x400    0x8000000
.text              0x3ea    0x8000400
.rodata              0x0    0x80007ec
.data                0x4   0x20000000
.ramfunc            0x28   0x20000004
.bss                 0x4   0x2000002c
```

# Unresolved questions?

- Is there a reliable way to initialize both `.data` and `.ramfunc` in a single
  for loop? (see `init_data` in the `Reset` function) Right now I initialize
  each one separately and this produces more code. I haven't tried initializing
  them in a single pass.

- Should `#[ramfunc]` imply `#[inline(never)]`? Right now the compiler is free
  to inline functions marked as `#[ramfunc]` into other functions. That could
  cause the function to *not* end in RAM.

- Bikeshed the attribute name and linker section name? IAR and TI use the name
  `ramfunc` for this functionality.

