### PR TITLE
v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.6.0] - 2018-09-06
+
+### Changed
+
+- [breaking-change] the `entry!`, `pre_init!` and `exception!` macros have been
+  replaced with attributes: `#[entry]`, `#[pre_init]` and `#[exception]`,
+  respectively. This also changes the toolchain requirement to 1.30-beta or
+  newer.
+
 ## [v0.5.3] - 2018-08-27
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["arm", "cortex-m", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"
 repository = "https://github.com/japaric/cortex-m-rt"
-version = "0.5.3"
+version = "0.6.0"
 
 [dependencies]
 r0 = "0.2.1"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -99,7 +99,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
 
     // XXX should we blacklist other attributes?
     let attrs = f.attrs;
-    let ident = f.ident;
+    let hash = random_ident();
     let (statics, stmts) = extract_static_muts(f.block.stmts);
 
     let vars = statics
@@ -123,11 +123,9 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
         }).collect::<Vec<_>>();
 
     quote!(
-        // TODO(forbid) see tests/compile-fail/entry-hidden.rs
-        // #[forbid(dead_code)]
         #[export_name = "main"]
         #(#attrs)*
-        pub fn #ident() -> ! {
+        pub fn #hash() -> ! {
             #(#vars)*
 
             #(#stmts)*

--- a/tests/compile-fail/entry-soundness.rs
+++ b/tests/compile-fail/entry-soundness.rs
@@ -1,0 +1,26 @@
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt;
+extern crate panic_semihosting;
+
+use cortex_m_rt::{entry, exception};
+
+#[entry]
+fn foo() -> ! {
+    static mut COUNT: u64 = 0;
+
+    loop {
+        if *COUNT % 2 == 0 {
+            *COUNT += 1;
+        } else {
+            *COUNT *= 2;
+        }
+    }
+}
+
+#[exception]
+fn SysTick() {
+    // If this was allowed it would lead to a data race as `SysTick` can preempt `foo`
+    foo(); //~ ERROR cannot find function `foo` in this scope
+}

--- a/tests/compile-fail/exception-soundness.rs
+++ b/tests/compile-fail/exception-soundness.rs
@@ -1,0 +1,29 @@
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt;
+extern crate panic_semihosting;
+
+use cortex_m_rt::{entry, exception};
+
+#[entry]
+fn foo() -> ! {
+    loop {}
+}
+
+#[exception]
+fn SysTick() {
+    static mut COUNT: u64 = 0;
+
+    if *COUNT % 2 == 0 {
+        *COUNT += 1;
+    } else {
+        *COUNT *= 2;
+    }
+}
+
+#[exception]
+fn SVCall() {
+    // If this was allowed it would lead to a data race as `SVCall` could preempt `SysTick`
+    SysTick(); //~ ERROR cannot find function `SysTick` in this scope
+}


### PR DESCRIPTION
this also adds compile-fail soundness tests and patches a soundness issue in
`#[entry]`

commit required to release a new (minor) version

r? @rust-embedded/cortex-m (anyone)