### PR TITLE
v0.6.0, take 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,11 @@
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
 categories = ["embedded", "no-std"]
 description = "Minimal runtime / startup for Cortex-M microcontrollers"
-documentation = "https://docs.rs/cortex-m-rt"
-readme = "README.md"
+documentation = "https://rust-embedded.github.io/cortex-m-rt/"
 keywords = ["arm", "cortex-m", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"
+readme = "README.md"
 repository = "https://github.com/japaric/cortex-m-rt"
 version = "0.6.0"
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
-name = "cortex-m-rt-macros"
-version = "0.1.0"
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
+categories = ["embedded", "no-std"]
+description = "Attributes re-exported in `cortex-m-rt`"
+documentation = "https://rust-embedded.github.io/cortex-m-rt"
+keywords = ["arm", "cortex-m", "runtime", "startup"]
+license = "MIT OR Apache-2.0"
+name = "cortex-m-rt-macros"
+repository = "https://github.com/japaric/cortex-m-rt"
+version = "0.1.0"
 
 [lib]
 proc-macro = true
@@ -16,4 +22,4 @@ features = ["extra-traits", "full"]
 version = "0.14.8"
 
 [dev-dependencies]
-cortex-m-rt = { path = ".." }
+cortex-m-rt = { path = "..", version = "0.6.0" }


### PR DESCRIPTION
the dev-dependency of cortex-m-rt-macros needs to specify a version or can't be
published; this commit fixes that

docs.rs won't be able to build docs for these two crates so this also changes
the documentation link to https://rust-embedded.github.io/cortex-m-rt/ where I
have (manually) implemented a poor man's docs.rs

now we should be able to publish a new version

r? @rust-embedded/cortex-m (anyone)