### PR TITLE
error during compilation if two copies of cortex-m-rt are being linked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.6.1] - 2018-09-06
+
+### Changed
+
+- Produce a better error message if two (or more) copies of `cortex-m-rt` are
+  going to be linked into a binary.
+
 ## [v0.6.0] - 2018-09-06
 
 ### Changed
@@ -351,7 +358,9 @@ section                size        addr
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.6.1...HEAD
+[v0.6.1]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.6.0...v0.6.1
+[v0.6.0]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.5.3...v0.6.0
 [v0.5.3]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.5.2...v0.5.3
 [v0.5.2]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.5.1...v0.5.2
 [v0.5.1]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.5.0...v0.5.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"
 readme = "README.md"
 repository = "https://github.com/japaric/cortex-m-rt"
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
 r0 = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,10 @@ use core::sync::atomic::{self, Ordering};
 
 pub use macros::{entry, exception, pre_init};
 
+#[export_name = "error: cortex-m-rt appears more than once in the dependency graph"]
+#[doc(hidden)]
+pub static __ONCE__: () = ();
+
 /// Registers stacked (pushed into the stack) during an exception
 #[derive(Clone, Copy)]
 #[repr(C)]


### PR DESCRIPTION
linking two copies into the final binary produces a confusing linker error
message. This improves the situation by producing an error at compile time.

This will have to be backported into the v0.5.x series or you won't get the new
error message.

r? @rust-embedded/cortex-m (anyone)