### PR TITLE
Disable default-features on rand dependency to avoid std version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ cortex-m = "0.5.4"
 panic-abort = "0.3.0"
 panic-semihosting = "0.4.0"
 
+[dev-dependencies.rand]
+default-features = false
+version = "0.5.5"
+
 [target.'cfg(not(target_os = "none"))'.dev-dependencies]
 compiletest_rs = "0.3.14"
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -20,11 +20,12 @@ main() {
         minimal
         override-exception
         pre_init
+        rand
         state
         unsafe-default-handler
-        unsafe-hard-fault
         unsafe-entry
         unsafe-exception
+        unsafe-hard-fault
     )
     local fail_examples=(
         data_overflow

--- a/examples/rand.rs
+++ b/examples/rand.rs
@@ -1,0 +1,24 @@
+//! Use rand crate to ensure it's configured for no_std compatbility
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt as rt;
+use rt::entry;
+
+extern crate panic_semihosting;
+
+extern crate rand;
+use rand::Rng;
+use rand::SeedableRng;
+
+// the program entry point
+#[entry]
+fn main() -> ! {
+    let seed: [u8; 32] = [0; 32];
+    let mut rng = rand::ChaChaRng::from_seed(seed);
+    let _ = rng.gen::<u32>();
+
+    loop {}
+}

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,12 +14,15 @@ proc-macro = true
 
 [dependencies]
 quote = "0.6.6"
-rand = "0.5.5"
 proc-macro2 = "0.4.15"
 
 [dependencies.syn]
 features = ["extra-traits", "full"]
 version = "0.14.8"
+
+[dependencies.rand]
+version = "0.5.5"
+default-features = false
 
 [dev-dependencies]
 cortex-m-rt = { path = "..", version = "0.6.0" }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,12 +4,18 @@ extern crate proc_macro;
 extern crate rand;
 #[macro_use]
 extern crate quote;
+extern crate core;
 extern crate proc_macro2;
 extern crate syn;
 
 use proc_macro2::Span;
 use rand::Rng;
+use rand::SeedableRng;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 use syn::{FnArg, Ident, Item, ItemFn, ItemStatic, ReturnType, Stmt, Type, Visibility};
+
+static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 use proc_macro::TokenStream;
 
@@ -492,7 +498,23 @@ pub fn pre_init(args: TokenStream, input: TokenStream) -> TokenStream {
 
 // Creates a random identifier
 fn random_ident() -> Ident {
-    let mut rng = rand::thread_rng();
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let count: u64 = CALL_COUNT.fetch_add(1, Ordering::SeqCst) as u64;
+    let mut seed: [u8; 16] = [0; 16];
+
+    for (i, v) in seed.iter_mut().take(8).enumerate() {
+        *v = ((secs >> (i * 8)) & 0xFF) as u8
+    }
+
+    for (i, v) in seed.iter_mut().skip(8).enumerate() {
+        *v = ((count >> (i * 8)) & 0xFF) as u8
+    }
+
+    let mut rng = rand::rngs::SmallRng::from_seed(seed);
     Ident::new(
         &(0..16)
             .map(|i| {


### PR DESCRIPTION
Due to the single dependency tree, the attempted use of a std version
flips all depending crates to the std version as well which will not
compile on no_std systems.

Fixes #105

Signed-off-by: Daniel Egger <daniel@eggers-club.de>