### PR TITLE
README: update the documentation link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["arm", "cortex-m", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"
 readme = "README.md"
-repository = "https://github.com/japaric/cortex-m-rt"
+repository = "https://github.com/rust-embedded/cortex-m-rt"
 version = "0.6.1"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 # `cortex-m-rt`
 
-> Minimal runtime / startup for Cortex-M microcontrollers
+> Startup code and minimal runtime for Cortex-M microcontrollers
 
 This project is developed and maintained by the [Cortex-M team][team].
 
-# [Documentation](https://docs.rs/cortex-m-rt)
+# [Documentation](https://rust-embedded.github.io/cortex-m-rt)
 
 # License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Minimal startup / runtime for Cortex-M microcontrollers
+//! Startup code and minimal runtime for Cortex-M microcontrollers
 //!
 //! This crate contains all the required parts to build a `no_std` application (binary crate) that
 //! targets a Cortex-M microcontroller.


### PR DESCRIPTION
because we have `readme = "README.md"` set in Cargo.toml the crates.io page
renders the README which contains a BIG "Documentation" link that points to
docs.rs which is broken. This commit makes that link point to our GH page.

r? @rust-embedded/cortex-m (anyone)

I have also observed that the smaller "documentation" link in the crates.io page
is ignoring the "documentation" field and pointing to docs.rs. I reported this
as a bug in rust-lang/crates.io#1485