### PR TITLE
v0.6.3 and v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.6.3] - 2018-09-09
+
+### Fixed
+
+- Fixed the `rand` problem for real.
+
 ## [v0.6.2] - 2018-09-09
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m-rt"
-version = "0.6.2"
+version = "0.6.3"
 
 [dependencies]
 r0 = "0.2.1"
-cortex-m-rt-macros = { path = "macros", version = "0.1.0" }
+cortex-m-rt-macros = { path = "macros", version = "0.1.1" }
 
 [dev-dependencies]
 cortex-m = "0.5.4"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["arm", "cortex-m", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-rt-macros"
 repository = "https://github.com/japaric/cortex-m-rt"
-version = "0.1.0"
+version = "0.1.1"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
fixes the `rand` issues

r? @rust-embedded/cortex-m (anyone)