### PR TITLE
make all exception handlers extern "C"

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -418,7 +418,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
             quote!(
                 #[export_name = #ident_s]
                 #(#attrs)*
-                pub fn #hash() {
+                pub extern "C" fn #hash() {
                     extern crate cortex_m_rt;
 
                     // check that this exception actually exists


### PR DESCRIPTION
They'll be called by the hardware and must comply to the stable C ABI.

Using the Rust ABI in this case was an oversight.

r? @rust-embedded/cortex-m (anyone)