### PR TITLE
respect declared unsafety

### DIFF
--- a/examples/unsafety.rs
+++ b/examples/unsafety.rs
@@ -1,0 +1,36 @@
+//! Checks that the declared unsafety is respected by the attributes
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt;
+extern crate panic_semihosting;
+
+use cortex_m_rt::{entry, exception, ExceptionFrame};
+
+#[entry]
+unsafe fn main() -> ! {
+    foo();
+
+    loop {}
+}
+
+#[exception]
+unsafe fn DefaultHandler(_irqn: i16) {
+    foo();
+}
+
+#[exception]
+unsafe fn HardFault(_ef: &ExceptionFrame) -> ! {
+    foo();
+
+    loop {}
+}
+
+#[exception]
+unsafe fn SysTick() {
+    foo();
+}
+
+unsafe fn foo() {}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -105,6 +105,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
 
     // XXX should we blacklist other attributes?
     let attrs = f.attrs;
+    let unsafety = f.unsafety;
     let hash = random_ident();
     let (statics, stmts) = extract_static_muts(f.block.stmts);
 
@@ -131,7 +132,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     quote!(
         #[export_name = "main"]
         #(#attrs)*
-        pub fn #hash() -> ! {
+        pub #unsafety fn #hash() -> ! {
             #(#vars)*
 
             #(#stmts)*
@@ -282,6 +283,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
     let attrs = f.attrs;
     let block = f.block;
     let stmts = block.stmts;
+    let unsafety = f.unsafety;
 
     let hash = random_ident();
     match exn {
@@ -313,7 +315,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
             quote!(
                 #[export_name = #ident_s]
                 #(#attrs)*
-                pub extern "C" fn #hash() {
+                pub #unsafety extern "C" fn #hash() {
                     extern crate core;
 
                     const SCB_ICSR: *const u32 = 0xE000_ED04 as *const u32;
@@ -362,7 +364,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
             quote!(
                 #[export_name = "UserHardFault"]
                 #(#attrs)*
-                pub extern "C" fn #hash(#arg) -> ! {
+                pub #unsafety extern "C" fn #hash(#arg) -> ! {
                     extern crate cortex_m_rt;
 
                     // further type check of the input argument
@@ -418,7 +420,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
             quote!(
                 #[export_name = #ident_s]
                 #(#attrs)*
-                pub extern "C" fn #hash() {
+                pub #unsafety extern "C" fn #hash() {
                     extern crate cortex_m_rt;
 
                     // check that this exception actually exists


### PR DESCRIPTION
the `#[entry]` and `#[exception]` attributes ignored the declared unsafety and
always expanded to a safe function. This caused the following valid code to
error at compile time:

``` rust
 #[entry]
unsafe fn main() -> ! {
    foo();
    //~^ ERROR call to unsafe function is unsafe and requires unsafe function or block

    loop {}
}

unsafe fn foo() {}
```

r? @rust-embedded/cortex-m (anyone)