### PR TITLE
use panic-halt instead of panic-{abort,semihosting}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ cortex-m-rt-macros = { path = "macros", version = "0.1.1" }
 
 [dev-dependencies]
 cortex-m = "0.5.4"
-panic-abort = "0.3.0"
-panic-semihosting = "0.4.0"
+panic-halt = "0.2.0"
 
 [dev-dependencies.rand]
 default-features = false

--- a/examples/alignment.rs
+++ b/examples/alignment.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 extern crate cortex_m_rt as rt;
-extern crate panic_abort;
+extern crate panic_halt;
 
 use core::ptr;
 

--- a/examples/data_overflow.rs
+++ b/examples/data_overflow.rs
@@ -6,7 +6,7 @@
 #![no_std]
 
 extern crate cortex_m_rt as rt;
-extern crate panic_abort;
+extern crate panic_halt;
 
 use core::ptr;
 

--- a/examples/device.rs
+++ b/examples/device.rs
@@ -6,7 +6,7 @@
 #![no_std]
 
 extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use rt::entry;
 

--- a/examples/divergent-default-handler.rs
+++ b/examples/divergent-default-handler.rs
@@ -4,7 +4,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/examples/divergent-exception.rs
+++ b/examples/divergent-exception.rs
@@ -3,7 +3,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/examples/entry-static.rs
+++ b/examples/entry-static.rs
@@ -6,7 +6,7 @@
 #![no_std]
 
 extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use rt::entry;
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 #[no_mangle]
 pub unsafe extern "C" fn main() -> ! {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -6,7 +6,7 @@
 #![no_std]
 
 extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use rt::entry;
 

--- a/examples/override-exception.rs
+++ b/examples/override-exception.rs
@@ -7,7 +7,7 @@
 
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m::asm;
 use rt::{entry, exception, ExceptionFrame};

--- a/examples/pre_init.rs
+++ b/examples/pre_init.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use rt::{entry, pre_init};
 

--- a/examples/rand.rs
+++ b/examples/rand.rs
@@ -7,7 +7,7 @@
 extern crate cortex_m_rt as rt;
 use rt::entry;
 
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 extern crate rand;
 use rand::Rng;

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -6,7 +6,7 @@
 #![no_std]
 
 extern crate cortex_m_rt as rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use rt::{entry, exception};
 

--- a/examples/unsafe-default-handler.rs
+++ b/examples/unsafe-default-handler.rs
@@ -3,7 +3,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/examples/unsafe-entry.rs
+++ b/examples/unsafe-entry.rs
@@ -3,7 +3,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::entry;
 

--- a/examples/unsafe-exception.rs
+++ b/examples/unsafe-exception.rs
@@ -3,7 +3,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/examples/unsafe-hard-fault.rs
+++ b/examples/unsafe-hard-fault.rs
@@ -3,7 +3,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception, ExceptionFrame};
 

--- a/examples/unsafety.rs
+++ b/examples/unsafety.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception, ExceptionFrame};
 

--- a/tests/compile-fail/default-handler-bad-signature-1.rs
+++ b/tests/compile-fail/default-handler-bad-signature-1.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/default-handler-bad-signature-2.rs
+++ b/tests/compile-fail/default-handler-bad-signature-2.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/default-handler-hidden.rs
+++ b/tests/compile-fail/default-handler-hidden.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/default-handler-twice.rs
+++ b/tests/compile-fail/default-handler-twice.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/entry-args.rs
+++ b/tests/compile-fail/entry-args.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::entry;
 

--- a/tests/compile-fail/entry-bad-signature-1.rs
+++ b/tests/compile-fail/entry-bad-signature-1.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::entry;
 

--- a/tests/compile-fail/entry-bad-signature-2.rs
+++ b/tests/compile-fail/entry-bad-signature-2.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::entry;
 

--- a/tests/compile-fail/entry-bad-signature-3.rs
+++ b/tests/compile-fail/entry-bad-signature-3.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::entry;
 

--- a/tests/compile-fail/entry-hidden.rs
+++ b/tests/compile-fail/entry-hidden.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 mod hidden {
     use cortex_m_rt::entry;

--- a/tests/compile-fail/entry-soundness.rs
+++ b/tests/compile-fail/entry-soundness.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/entry-twice.rs
+++ b/tests/compile-fail/entry-twice.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::entry;
 

--- a/tests/compile-fail/exception-args.rs
+++ b/tests/compile-fail/exception-args.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/exception-bad-signature-1.rs
+++ b/tests/compile-fail/exception-bad-signature-1.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/exception-bad-signature-2.rs
+++ b/tests/compile-fail/exception-bad-signature-2.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/exception-hidden.rs
+++ b/tests/compile-fail/exception-hidden.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/exception-soundness.rs
+++ b/tests/compile-fail/exception-soundness.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/exception-twice.rs
+++ b/tests/compile-fail/exception-twice.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception};
 

--- a/tests/compile-fail/hard-fault-bad-signature-1.rs
+++ b/tests/compile-fail/hard-fault-bad-signature-1.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception, ExceptionFrame};
 

--- a/tests/compile-fail/hard-fault-hidden.rs
+++ b/tests/compile-fail/hard-fault-hidden.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception, ExceptionFrame};
 

--- a/tests/compile-fail/hard-fault-twice.rs
+++ b/tests/compile-fail/hard-fault-twice.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, exception, ExceptionFrame};
 

--- a/tests/compile-fail/pre-init-args.rs
+++ b/tests/compile-fail/pre-init-args.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, pre_init};
 

--- a/tests/compile-fail/pre-init-bad-signature-1.rs
+++ b/tests/compile-fail/pre-init-bad-signature-1.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, pre_init};
 

--- a/tests/compile-fail/pre-init-bad-signature-2.rs
+++ b/tests/compile-fail/pre-init-bad-signature-2.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, pre_init};
 

--- a/tests/compile-fail/pre-init-hidden.rs
+++ b/tests/compile-fail/pre-init-hidden.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 mod hidden {
     use cortex_m_rt::pre_init;

--- a/tests/compile-fail/pre-init-twice.rs
+++ b/tests/compile-fail/pre-init-twice.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 extern crate cortex_m_rt;
-extern crate panic_semihosting;
+extern crate panic_halt;
 
 use cortex_m_rt::{entry, pre_init};
 


### PR DESCRIPTION
the former requires a feature gate; the later pulls in the cortex-m crate

Eventually we want to test this crate on beta. To do that our dependencies must
not contain feature gates. That's not the case of `panic-abort`, which depends
on the `core_intrinsics` feature.

This PR fixes that. I could have used `panic-semihosting` everywhere but decided
for `panic-halt` which has zero dependencies as I figured that might slightly
decrease CI times.