### PR TITLE
bump the syn dependency

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,12 +13,12 @@ version = "0.1.1"
 proc-macro = true
 
 [dependencies]
-quote = "0.6.6"
-proc-macro2 = "0.4.15"
+quote = "0.6.8"
+proc-macro2 = "0.4.19"
 
 [dependencies.syn]
 features = ["extra-traits", "full"]
-version = "0.14.8"
+version = "0.15.4"
 
 [dependencies.rand]
 version = "0.5.5"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -6,6 +6,7 @@ extern crate rand;
 extern crate quote;
 extern crate core;
 extern crate proc_macro2;
+#[macro_use]
 extern crate syn;
 
 use proc_macro2::Span;
@@ -77,7 +78,7 @@ use proc_macro::TokenStream;
 /// ```
 #[proc_macro_attribute]
 pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
-    let f: ItemFn = syn::parse(input).expect("`#[entry]` must be applied to a function");
+    let f = parse_macro_input!(input as ItemFn);
 
     // check the function signature
     assert!(
@@ -253,7 +254,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
-    let f: ItemFn = syn::parse(input).expect("`#[exception]` must be applied to a function");
+    let f = parse_macro_input!(input as ItemFn);
 
     assert!(
         args.to_string() == "",
@@ -459,7 +460,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn pre_init(args: TokenStream, input: TokenStream) -> TokenStream {
-    let f: ItemFn = syn::parse(input).expect("`#[pre_init]` must be applied to a function");
+    let f = parse_macro_input!(input as ItemFn);
 
     // check the function signature
     assert!(


### PR DESCRIPTION
and switch to the recommended way to parse tokens: `parse_macro_input!`.

This improves (?) error messages when the user applies one of our attributes to
an item that's not a function.

Consider

``` rust
 #[entry]
static MAIN: () = ();

```

The error message changed from:

```
error: custom attribute panicked
  --> src/main.rs:10:1
   |
10 | #[entry]
   | ^^^^^^^^
   |
   = help: message: `#[entry]` must be applied to a function: ParseError(Some("failed to parse fn item: failed to parse"))
```

to:

```
error: expected `fn`
  --> src/main.rs:11:1
   |
11 | static MAIN: () = ();
   | ^^^^^^

error: aborting due to previous error
```

---

Before landing this I'd like to hear more details about #125 to see if this
helps