### PR TITLE
Add qemu example and run in CI

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,6 +2,11 @@
 # uncomment this to make `cargo run` execute programs on QEMU
 runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
 
+[target.thumbv6m-none-eabi]
+# uncomment this to make `cargo run` execute programs on QEMU
+# For now, we use cortex-m3 instead of cortex-m0 which are not supported by QEMU
+runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
+
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # uncomment ONE of these three option to make `cargo run` start a GDB session
 # which option to pick depends on your system

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,26 @@
 [target.thumbv7m-none-eabi]
 # uncomment this to make `cargo run` execute programs on QEMU
-runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -semihosting-config enable=on,target=native -nographic -kernel"
+runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
+
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# uncomment ONE of these three option to make `cargo run` start a GDB session
+# which option to pick depends on your system
+# runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+# runner = "gdb-multiarch -q -x openocd.gdb"
+# runner = "gdb -q -x openocd.gdb"
+
+rustflags = [
+  # LLD (shipped with the Rust toolchain) is used as the default linker
+  "-C", "link-arg=-Tlink.x",
+
+  # if you run into problems with LLD switch to the GNU linker by commenting out
+  # this line
+  # "-C", "linker=arm-none-eabi-ld",
+
+  # if you need to link to pre-compiled C libraries provided by a C toolchain
+  # use GCC as the linker by commenting out both lines above and then
+  # uncommenting the three lines below
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
+]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[target.thumbv7m-none-eabi]
+# uncomment this to make `cargo run` execute programs on QEMU
+runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -semihosting-config enable=on,target=native -nographic -kernel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: rust
 
+addons:
+  apt:
+    packages:
+    - qemu-system-arm
+
 matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: rust
 
-addons:
-  apt:
-    packages:
-    - qemu-system-arm
-
 matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
@@ -52,7 +47,7 @@ before_install: set -e
 
 install:
   - bash ci/install.sh
-  - export PATH="$PATH:$PWD/gcc/bin"
+  - export PATH="$PATH:$PWD/gcc/bin:$PWD/qemu"
 
 script:
   - bash ci/script.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ cortex-m-rt-macros = { path = "macros", version = "0.1.1" }
 [dev-dependencies]
 cortex-m = "0.5.4"
 panic-halt = "0.2.0"
+panic-semihosting = "0.5.0"
+cortex-m-semihosting = "0.3.1"
+unreachable = "1.0.0"
 
 [dev-dependencies.rand]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
+authors = ["Jorge Aparicio <jorge@japaric.io>", "Hideki Sekine <sekineh@me.com>"]
 categories = ["embedded", "no-std"]
 description = "Minimal runtime / startup for Cortex-M microcontrollers"
 documentation = "https://rust-embedded.github.io/cortex-m-rt/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ cortex-m-rt-macros = { path = "macros", version = "0.1.1" }
 [dev-dependencies]
 cortex-m = "0.5.4"
 panic-halt = "0.2.0"
-panic-semihosting = "0.5.0"
 cortex-m-semihosting = "0.3.1"
-unreachable = "1.0.0"
 
 [dev-dependencies.rand]
 default-features = false

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -8,6 +8,10 @@ main() {
     mkdir gcc
 
     curl -L https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2?revision=bc2c96c0-14b5-4bb4-9f18-bceb4050fee7?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2018-q2-update | tar --strip-components=1 -C gcc -xj
+
+    mkdir qemu
+    curl -L https://github.com/japaric/qemu-bin/raw/master/14.04/qemu-system-arm-2.12.0 > qemu/qemu-system-arm
+    chmod +x qemu/qemu-system-arm
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -70,11 +70,10 @@ main() {
 
     case $TARGET in
         thumbv6m-none-eabi|thumbv7m-none-eabi)
-            # linking with GNU LD
-            cargo run --target $TARGET --example qemu -- \
-                  -C linker=arm-none-eabi-ld | grep "x = 42"
-            cargo run --target $TARGET --example qemu --release -- \
-                  -C linker=arm-none-eabi-ld | grep "x = 42"
+            # linking with GNU LD (not working now; needs Ctrl+a x to exit)
+            #env RUSTFLAGS="-C linker=arm-none-eabi-ld" cargo run --target $TARGET --example qemu | grep "x = 42"
+            #env RUSTFLAGS="-C linker=arm-none-eabi-ld" cargo run --target $TARGET --example qemu --release | grep "x = 42"
+            
             # linking with rustc's LLD
             cargo run --target $TARGET --example qemu | grep "x = 42"
             cargo run --target $TARGET --example qemu --release | grep "x = 42"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -70,6 +70,12 @@ main() {
 
     case $TARGET in
         thumbv6m-none-eabi|thumbv7m-none-eabi)
+            # linking with GNU LD
+            cargo run --target $TARGET --example qemu \
+                  -C linker=arm-none-eabi-ld | grep "x = 42"
+            cargo run --target $TARGET --example qemu --release \
+                  -C linker=arm-none-eabi-ld | grep "x = 42"
+            # linking with rustc's LLD
             cargo run --target $TARGET --example qemu | grep "x = 42"
             cargo run --target $TARGET --example qemu --release | grep "x = 42"
             ;;

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -70,7 +70,7 @@ main() {
 
     case $TARGET in
         thumbv6m-none-eabi|thumbv7m-none-eabi)
-            # linking with GNU LD (not working now; needs Ctrl+a x to exit)
+            # linking with GNU LD
             env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" cargo run --target $TARGET --example qemu | grep "x = 42"
             env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" cargo run --target $TARGET --example qemu --release | grep "x = 42"
             

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -36,51 +36,51 @@ main() {
         for ex in "${examples[@]}"; do
             cargo rustc --target $TARGET --example $ex -- \
                   -C linker=arm-none-eabi-ld \
-                  -C link-arg=-Tlink.x
+                  #-C link-arg=-Tlink.x
 
             cargo rustc --target $TARGET --example $ex --release -- \
                   -C linker=arm-none-eabi-ld \
-                  -C link-arg=-Tlink.x
+                  #-C link-arg=-Tlink.x
         done
         for ex in "${fail_examples[@]}"; do
             ! cargo rustc --target $TARGET --example $ex -- \
                   -C linker=arm-none-eabi-ld \
-                  -C link-arg=-Tlink.x
+                  #-C link-arg=-Tlink.x
 
             ! cargo rustc --target $TARGET --example $ex --release -- \
                   -C linker=arm-none-eabi-ld \
-                  -C link-arg=-Tlink.x
+                  #-C link-arg=-Tlink.x
         done
 
         cargo rustc --target $TARGET --example device --features device -- \
               -C linker=arm-none-eabi-ld \
-              -C link-arg=-Tlink.x
+              #-C link-arg=-Tlink.x
 
         cargo rustc --target $TARGET --example device --features device --release -- \
               -C linker=arm-none-eabi-ld \
-              -C link-arg=-Tlink.x
+              #-C link-arg=-Tlink.x
 
         # linking with rustc's LLD
         for ex in "${examples[@]}"; do
             cargo rustc --target $TARGET --example $ex -- \
-                  -C link-arg=-Tlink.x
+                  #-C link-arg=-Tlink.x
 
             cargo rustc --target $TARGET --example $ex --release -- \
-                  -C link-arg=-Tlink.x
+                  #-C link-arg=-Tlink.x
         done
         for ex in "${fail_examples[@]}"; do
             ! cargo rustc --target $TARGET --example $ex -- \
-                  -C link-arg=-Tlink.x
+                  #-C link-arg=-Tlink.x
 
             ! cargo rustc --target $TARGET --example $ex --release -- \
-                  -C link-arg=-Tlink.x
+                  #-C link-arg=-Tlink.x
         done
 
         cargo rustc --target $TARGET --example device --features device -- \
-              -C link-arg=-Tlink.x
+              #-C link-arg=-Tlink.x
 
         cargo rustc --target $TARGET --example device --features device --release -- \
-              -C link-arg=-Tlink.x
+              #-C link-arg=-Tlink.x
     fi
 
     case $TARGET in

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -35,52 +35,37 @@ main() {
         # linking with GNU LD
         for ex in "${examples[@]}"; do
             cargo rustc --target $TARGET --example $ex -- \
-                  -C linker=arm-none-eabi-ld \
-                  #-C link-arg=-Tlink.x
+                  -C linker=arm-none-eabi-ld
 
             cargo rustc --target $TARGET --example $ex --release -- \
-                  -C linker=arm-none-eabi-ld \
-                  #-C link-arg=-Tlink.x
+                  -C linker=arm-none-eabi-ld
         done
         for ex in "${fail_examples[@]}"; do
             ! cargo rustc --target $TARGET --example $ex -- \
-                  -C linker=arm-none-eabi-ld \
-                  #-C link-arg=-Tlink.x
+                  -C linker=arm-none-eabi-ld
 
             ! cargo rustc --target $TARGET --example $ex --release -- \
-                  -C linker=arm-none-eabi-ld \
-                  #-C link-arg=-Tlink.x
+                  -C linker=arm-none-eabi-ld
         done
 
         cargo rustc --target $TARGET --example device --features device -- \
-              -C linker=arm-none-eabi-ld \
-              #-C link-arg=-Tlink.x
+              -C linker=arm-none-eabi-ld
 
         cargo rustc --target $TARGET --example device --features device --release -- \
-              -C linker=arm-none-eabi-ld \
-              #-C link-arg=-Tlink.x
+              -C linker=arm-none-eabi-ld
 
         # linking with rustc's LLD
         for ex in "${examples[@]}"; do
-            cargo rustc --target $TARGET --example $ex -- \
-                  #-C link-arg=-Tlink.x
-
-            cargo rustc --target $TARGET --example $ex --release -- \
-                  #-C link-arg=-Tlink.x
+            cargo rustc --target $TARGET --example $ex
+            cargo rustc --target $TARGET --example $ex --release
         done
         for ex in "${fail_examples[@]}"; do
-            ! cargo rustc --target $TARGET --example $ex -- \
-                  #-C link-arg=-Tlink.x
-
-            ! cargo rustc --target $TARGET --example $ex --release -- \
-                  #-C link-arg=-Tlink.x
+            ! cargo rustc --target $TARGET --example $ex
+            ! cargo rustc --target $TARGET --example $ex --release
         done
 
-        cargo rustc --target $TARGET --example device --features device -- \
-              #-C link-arg=-Tlink.x
-
-        cargo rustc --target $TARGET --example device --features device --release -- \
-              #-C link-arg=-Tlink.x
+        cargo rustc --target $TARGET --example device --features device
+        cargo rustc --target $TARGET --example device --features device --release
     fi
 
     case $TARGET in

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -20,6 +20,7 @@ main() {
         minimal
         override-exception
         pre_init
+        qemu
         rand
         state
         unsafe-default-handler
@@ -81,6 +82,13 @@ main() {
         cargo rustc --target $TARGET --example device --features device --release -- \
               -C link-arg=-Tlink.x
     fi
+
+    case $TARGET in
+        thumbv6m-none-eabi|thumbv7m-none-eabi)
+            cargo run --target $TARGET --example qemu | grep "x = 42"
+            cargo run --target $TARGET --example qemu --release | grep "x = 42"
+            ;;
+    esac
 
     if [ $TARGET = x86_64-unknown-linux-gnu ]; then
         ./check-blobs.sh

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -71,8 +71,8 @@ main() {
     case $TARGET in
         thumbv6m-none-eabi|thumbv7m-none-eabi)
             # linking with GNU LD (not working now; needs Ctrl+a x to exit)
-            #env RUSTFLAGS="-C linker=arm-none-eabi-ld" cargo run --target $TARGET --example qemu | grep "x = 42"
-            #env RUSTFLAGS="-C linker=arm-none-eabi-ld" cargo run --target $TARGET --example qemu --release | grep "x = 42"
+            env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" cargo run --target $TARGET --example qemu | grep "x = 42"
+            env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" cargo run --target $TARGET --example qemu --release | grep "x = 42"
             
             # linking with rustc's LLD
             cargo run --target $TARGET --example qemu | grep "x = 42"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -71,9 +71,9 @@ main() {
     case $TARGET in
         thumbv6m-none-eabi|thumbv7m-none-eabi)
             # linking with GNU LD
-            cargo run --target $TARGET --example qemu \
+            cargo run --target $TARGET --example qemu -- \
                   -C linker=arm-none-eabi-ld | grep "x = 42"
-            cargo run --target $TARGET --example qemu --release \
+            cargo run --target $TARGET --example qemu --release -- \
                   -C linker=arm-none-eabi-ld | grep "x = 42"
             # linking with rustc's LLD
             cargo run --target $TARGET --example qemu | grep "x = 42"

--- a/examples/qemu.rs
+++ b/examples/qemu.rs
@@ -1,0 +1,53 @@
+#![feature(stdsimd)]
+#![no_main]
+#![no_std]
+
+extern crate cortex_m;
+
+#[macro_use(entry, exception)]
+extern crate cortex_m_rt as rt;
+extern crate cortex_m_semihosting as semihosting;
+extern crate panic_abort;
+extern crate unreachable;
+
+use core::arch::arm;
+use core::fmt::Write;
+use rt::ExceptionFrame;
+
+entry!(main);
+
+fn main() -> ! {
+    let x = 42;
+
+    loop {
+        unsafe { arm::__NOP() }
+
+        // write something through semihosting interface
+        let mut hstdout = semihosting::hio::hstdout().unwrap();
+        write!(hstdout, "x = {}\n", x);
+
+        // exit from qemu
+        semihosting::debug::exit(semihosting::debug::EXIT_SUCCESS);
+
+        // hint to the optimizer that any code path which calls this function is statically unreachable
+        unsafe {
+            unreachable::unreachable();
+        }
+    }
+}
+
+// define the hard fault handler
+exception!(HardFault, hard_fault);
+
+#[inline(always)]
+fn hard_fault(_ef: &ExceptionFrame) -> ! {
+    loop {
+        unsafe { arm::__NOP() }
+    }
+}
+
+// define the default exception handler
+exception!(*, default_handler);
+
+#[inline(always)]
+fn default_handler(_irqn: i16) {}

--- a/examples/qemu.rs
+++ b/examples/qemu.rs
@@ -6,12 +6,11 @@ extern crate cortex_m;
 
 extern crate cortex_m_rt as rt;
 extern crate cortex_m_semihosting as semihosting;
-extern crate panic_semihosting;
-extern crate unreachable;
+extern crate panic_halt;
 
 use core::fmt::Write;
 use cortex_m::asm;
-use rt::{entry, exception, ExceptionFrame};
+use rt::entry;
 
 #[entry]
 fn main() -> ! {
@@ -24,32 +23,7 @@ fn main() -> ! {
         let mut hstdout = semihosting::hio::hstdout().unwrap();
         write!(hstdout, "x = {}\n", x);
 
-        asm::nop();
-
         // exit from qemu
         semihosting::debug::exit(semihosting::debug::EXIT_SUCCESS);
-
-        // hint to the optimizer that any code path which calls this function is statically unreachable
-        unsafe {
-            unreachable::unreachable();
-        }
     }
 }
-
-#[exception]
-#[inline(always)]
-fn HardFault(_ef: &ExceptionFrame) -> ! {
-    loop {
-        asm::nop()
-    }
-}
-
-#[exception]
-#[inline(always)]
-fn DefaultHandler(_irqn: i16) {}
-
-// use core::panic::PanicInfo;
-// #[panic_handler]
-// fn panic(_info: &PanicInfo) -> ! {{
-//     semihosting::debug::exit(semihosting::debug::EXIT_SUCCESS)}
-// }

--- a/memory.x
+++ b/memory.x
@@ -7,8 +7,8 @@ MEMORY
 {
   /* FLASH and RAM are mandatory memory regions */
   /* Update examples/data_overflow.rs if you change these sizes. */
-  FLASH : ORIGIN = 0x08000000, LENGTH = 64K
-  RAM : ORIGIN = 0x20000000, LENGTH = 20K
+  FLASH : ORIGIN = 0x00000000, LENGTH = 256K
+  RAM : ORIGIN = 0x20000000, LENGTH = 64K
 
   /* More memory regions can declared: for example this is a second RAM region */
   /* CCRAM : ORIGIN = 0x10000000, LENGTH = 8K */


### PR DESCRIPTION
As @japaric has suggested I ported `lm3s6965evb/src/main.rs` into `example/qemu.rs`.

All errors were fixed, ~but qemu never exits automatically~ `qemu` prints text and exits.
```
sekineh@sekineh-VirtualBox:~/cortex-m-rt_me$ cargo run --example qemu --target thumbv7m-none-eabi
   Compiling cortex-m-rt v0.6.3 (file:///home/sekineh/cortex-m-rt_me)                                            
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel target/thumbv7m-none-eabi/debug/examples/qemu`
x = 42
sekineh@sekineh-VirtualBox:~/cortex-m-rt_me$
```
## supported targets

- thumbv6m-none-eabi
- thumbv7m-none-eabi

## code size

~code size is 0, which is apparently wrong:~
```
sekineh@sekineh-VirtualBox:~/cortex-m-rt_me$ size target/thumbv7m-none-eabi/debug/examples/qemu
   text	   data	    bss	    dec	    hex	filename
  10776	      0	      0	  10776	   2a18	target/thumbv7m-none-eabi/debug/examples/qemu
```

## code size (original)
(deleted; different compiler version)