### PR TITLE
attributes: turn panics into compile errors

### DIFF
--- a/tests/compile-fail/default-handler-bad-signature-1.rs
+++ b/tests/compile-fail/default-handler-bad-signature-1.rs
@@ -11,6 +11,6 @@ fn foo() -> ! {
     loop {}
 }
 
-#[exception] //~ ERROR custom attribute panicked
-//~^ HELP `DefaultHandler` exception must have signature `[unsafe] fn(i16) [-> !]`
+#[exception]
 fn DefaultHandler(_irqn: i16, undef: u32) {}
+//~^ ERROR `DefaultHandler` must have signature `[unsafe] fn(i16) [-> !]`

--- a/tests/compile-fail/default-handler-bad-signature-2.rs
+++ b/tests/compile-fail/default-handler-bad-signature-2.rs
@@ -11,8 +11,8 @@ fn foo() -> ! {
     loop {}
 }
 
-#[exception] //~ ERROR custom attribute panicked
-//~^ HELP `DefaultHandler` exception must have signature `[unsafe] fn(i16) [-> !]`
+#[exception]
 fn DefaultHandler(_irqn: i16) -> u32 {
+    //~^ ERROR `DefaultHandler` must have signature `[unsafe] fn(i16) [-> !]`
     0
 }

--- a/tests/compile-fail/entry-args.rs
+++ b/tests/compile-fail/entry-args.rs
@@ -6,8 +6,7 @@ extern crate panic_halt;
 
 use cortex_m_rt::entry;
 
-#[entry(foo)] //~ ERROR custom attribute panicked
-//~^ HELP `entry` attribute must have no arguments
+#[entry(foo)] //~ ERROR This attribute accepts no arguments
 fn foo() -> ! {
     loop {}
 }

--- a/tests/compile-fail/entry-bad-signature-1.rs
+++ b/tests/compile-fail/entry-bad-signature-1.rs
@@ -6,6 +6,6 @@ extern crate panic_halt;
 
 use cortex_m_rt::entry;
 
-#[entry] //~ ERROR custom attribute panicked
-//~^ HELP `#[entry]` function must have signature `[unsafe] fn() -> !`
+#[entry]
 fn foo() {}
+//~^ ERROR `#[entry]` function must have signature `[unsafe] fn() -> !`

--- a/tests/compile-fail/entry-bad-signature-2.rs
+++ b/tests/compile-fail/entry-bad-signature-2.rs
@@ -6,6 +6,6 @@ extern crate panic_halt;
 
 use cortex_m_rt::entry;
 
-#[entry] //~ ERROR custom attribute panicked
-//~^ HELP `#[entry]` function must have signature `[unsafe] fn() -> !`
+#[entry]
 fn foo(undef: i32) -> ! {}
+//~^ ERROR `#[entry]` function must have signature `[unsafe] fn() -> !`

--- a/tests/compile-fail/entry-bad-signature-3.rs
+++ b/tests/compile-fail/entry-bad-signature-3.rs
@@ -6,8 +6,8 @@ extern crate panic_halt;
 
 use cortex_m_rt::entry;
 
-#[entry] //~ ERROR custom attribute panicked
-//~^ HELP `#[entry]` function must have signature `[unsafe] fn() -> !`
+#[entry]
 extern "C" fn foo() -> ! {
+    //~^ ERROR `#[entry]` function must have signature `[unsafe] fn() -> !`
     loop {}
 }

--- a/tests/compile-fail/exception-args.rs
+++ b/tests/compile-fail/exception-args.rs
@@ -11,6 +11,5 @@ fn foo() -> ! {
     loop {}
 }
 
-#[exception(SysTick)] //~ ERROR custom attribute panicked
-//~^ HELP `exception` attribute must have no arguments
+#[exception(SysTick)] //~ ERROR This attribute accepts no arguments
 fn SysTick() {}

--- a/tests/compile-fail/exception-bad-signature-1.rs
+++ b/tests/compile-fail/exception-bad-signature-1.rs
@@ -11,6 +11,6 @@ fn foo() -> ! {
     loop {}
 }
 
-#[exception] //~ ERROR custom attribute panicked
-//~^ HELP `#[exception]` functions other than `DefaultHandler` and `HardFault` must have signature `[unsafe] fn() [-> !]`
+#[exception]
 fn SysTick(undef: u32) {}
+//~^ ERROR `#[exception]` handlers other than `DefaultHandler` and `HardFault` must have signature `[unsafe] fn() [-> !]`

--- a/tests/compile-fail/exception-bad-signature-2.rs
+++ b/tests/compile-fail/exception-bad-signature-2.rs
@@ -11,8 +11,8 @@ fn foo() -> ! {
     loop {}
 }
 
-#[exception] //~ ERROR custom attribute panicked
-//~^ HELP `#[exception]` functions other than `DefaultHandler` and `HardFault` must have signature `[unsafe] fn() [-> !]`
+#[exception]
 fn SysTick() -> u32 {
+    //~^ ERROR `#[exception]` handlers other than `DefaultHandler` and `HardFault` must have signature `[unsafe] fn() [-> !]`
     0
 }

--- a/tests/compile-fail/hard-fault-bad-signature-1.rs
+++ b/tests/compile-fail/hard-fault-bad-signature-1.rs
@@ -11,8 +11,8 @@ fn foo() -> ! {
     loop {}
 }
 
-#[exception] //~ ERROR custom attribute panicked
-//~^ HELP `HardFault` exception must have signature `[unsafe] fn(&ExceptionFrame) -> !`
+#[exception]
 fn HardFault(_ef: &ExceptionFrame, undef: u32) -> ! {
+    //~^ ERROR `HardFault` handler must have signature `[unsafe] fn(&ExceptionFrame) -> !`
     loop {}
 }

--- a/tests/compile-fail/interrupt-args.rs
+++ b/tests/compile-fail/interrupt-args.rs
@@ -15,6 +15,5 @@ enum interrupt {
     USART1,
 }
 
-#[interrupt(true)] //~ ERROR custom attribute panicked
-//~^ HELP `interrupt` attribute must have no arguments
+#[interrupt(true)] //~ ERROR This attribute accepts no arguments
 fn USART1() {}

--- a/tests/compile-fail/interrupt-bad-signature-1.rs
+++ b/tests/compile-fail/interrupt-bad-signature-1.rs
@@ -15,6 +15,6 @@ enum interrupt {
     USART1,
 }
 
-#[interrupt] //~ ERROR custom attribute panicked
-//~^ HELP `#[interrupt]` functions must have signature `[unsafe] fn() [-> !]`
+#[interrupt]
 fn USART1(undef: i32) {}
+//~^ ERROR `#[interrupt]` handlers must have signature `[unsafe] fn() [-> !]`

--- a/tests/compile-fail/interrupt-bad-signature-2.rs
+++ b/tests/compile-fail/interrupt-bad-signature-2.rs
@@ -15,8 +15,8 @@ enum interrupt {
     USART1,
 }
 
-#[interrupt] //~ ERROR custom attribute panicked
-//~^ HELP `#[interrupt]` functions must have signature `[unsafe] fn() [-> !]`
+#[interrupt]
 fn USART1() -> i32 {
+    //~^ ERROR `#[interrupt]` handlers must have signature `[unsafe] fn() [-> !]`
     0
 }

--- a/tests/compile-fail/pre-init-args.rs
+++ b/tests/compile-fail/pre-init-args.rs
@@ -6,8 +6,7 @@ extern crate panic_halt;
 
 use cortex_m_rt::{entry, pre_init};
 
-#[pre_init(foo)] //~ ERROR custom attribute panicked
-//~^ HELP `pre_init` attribute must have no arguments
+#[pre_init(foo)] //~ ERROR This attribute accepts no arguments
 unsafe fn foo() {}
 
 #[entry]

--- a/tests/compile-fail/pre-init-bad-signature-1.rs
+++ b/tests/compile-fail/pre-init-bad-signature-1.rs
@@ -6,9 +6,9 @@ extern crate panic_halt;
 
 use cortex_m_rt::{entry, pre_init};
 
-#[pre_init] //~ ERROR custom attribute panicked
-//~^ HELP `#[pre_init]` function must have signature `unsafe fn()`
+#[pre_init]
 fn foo() {}
+//~^ ERROR `#[pre_init]` function must have signature `unsafe fn()`
 
 #[entry]
 fn bar() -> ! {

--- a/tests/compile-fail/pre-init-bad-signature-2.rs
+++ b/tests/compile-fail/pre-init-bad-signature-2.rs
@@ -6,9 +6,9 @@ extern crate panic_halt;
 
 use cortex_m_rt::{entry, pre_init};
 
-#[pre_init] //~ ERROR custom attribute panicked
-//~^ HELP `#[pre_init]` function must have signature `unsafe fn()`
+#[pre_init]
 unsafe fn foo(undef: i32) {}
+//~^ ERROR `#[pre_init]` function must have signature `unsafe fn()`
 
 #[entry]
 fn bar() -> ! {


### PR DESCRIPTION
Sample error messages:

```
error: `#[entry]` function must have signature `[unsafe] fn() -> !`
  --> examples/error.rs:15:1
   |
15 | fn main() {
   | ^^

error: aborting due to previous error
```

```
error: This attribute accepts no arguments
  --> examples/error.rs:14:1
   |
14 | #[entry(hello)]
   | ^^^^^^^^^^^^^^^

error: aborting due to previous error
```

```
error: This is not a valid exception name
  --> examples/error.rs:20:4
   |
20 | fn foo() {}
   |    ^^^

error: aborting due to previous error
```