### PR TITLE
reject duplicate `static mut` variables

### DIFF
--- a/tests/compile-fail/duplicate-static.rs
+++ b/tests/compile-fail/duplicate-static.rs
@@ -1,0 +1,31 @@
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt;
+extern crate panic_halt;
+
+use cortex_m_rt::{entry, exception, interrupt};
+
+enum interrupt {
+    UART0,
+}
+
+#[entry]
+fn foo() -> ! {
+    static mut X: u32 = 0;
+    static mut X: i32 = 0; //~ ERROR the name `X` is defined multiple times
+
+    loop {}
+}
+
+#[exception]
+fn SVCall() {
+    static mut X: u32 = 0;
+    static mut X: i32 = 0; //~ ERROR the name `X` is defined multiple times
+}
+
+#[interrupt]
+fn UART0() {
+    static mut X: u32 = 0;
+    static mut X: i32 = 0; //~ ERROR the name `X` is defined multiple times
+}


### PR DESCRIPTION
after #140 landed the entry, exception and interrupt attributes started
accepting code like this:

``` rust
 #[entry]
fn main() -> ! {
    static mut FOO: u32 = 0;
    static mut FOO: i32 = 0;
}
```

because that code expands into:

``` rust
fn main() -> ! {
    let FOO: &'static mut u32 = unsafe {
        static mut FOO: u32 = 0;
        &mut FOO
    };
    // shadows previous variable
    let FOO: &'static mut u32 = unsafe {
        static mut FOO: i32 = 0;
        &mut FOO
    };
}
```

this commit adds a check that rejects `static mut`s with duplicated names to
these three attributes.