### PR TITLE
static mut transform: forward `#[cfg]`

### DIFF
--- a/examples/cfg-static.rs
+++ b/examples/cfg-static.rs
@@ -1,0 +1,25 @@
+//! using `#[cfg]` on `static` shouldn't cause compile errors
+
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt as rt;
+extern crate panic_halt;
+
+use rt::{entry, exception};
+
+#[entry]
+fn main() -> ! {
+    #[cfg(never)]
+    static mut COUNT: u32 = 0;
+
+    loop {}
+}
+
+#[exception]
+fn SysTick() {
+    #[cfg(never)]
+    static mut FOO: u32 = 0;
+}


### PR DESCRIPTION
as reported in japaric/cortex-m-rtfm#110 the following code fails to compile

``` rust
 #[entry]
fn main() -> ! {
    #[cfg(something)]
    static mut FOO: u32 = 0; //~ ERROR cannot find value `FOO` in this scope
}
```

the issue is that the expansion of the static looks like this:

``` rust
let FOO = unsafe {
    #[cfg(never)]
    static mut FOO: u32 = 0;

    &mut FOO
};
```

so when the `#[cfg]` evals to false the static is gone but the `let FOO` is not
removed.

this PR forwards `#[cfg]` attributes to the `let` expression and fixes the error

``` rust
 #[cfg(never)] // <- added
let FOO = unsafe {
    #[cfg(never)]
    static mut FOO: u32 = 0;

    &mut FOO
};
```