### PR TITLE
Fix linker asserts for vector table not located at address 0.

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -177,10 +177,10 @@ BUG(cortex-m-rt): start of .heap is not 4-byte aligned");
 /* # Position checks */
 
 /* ## .vector_table */
-ASSERT(__reset_vector == ADDR(.vector_table) + 0x8, "
+ASSERT(ABSOLUTE(__reset_vector) == ADDR(.vector_table) + 0x8, "
 BUG(cortex-m-rt): the reset vector is missing");
 
-ASSERT(__eexceptions == ADDR(.vector_table) + 0x40, "
+ASSERT(ABSOLUTE(__eexceptions) == ADDR(.vector_table) + 0x40, "
 BUG(cortex-m-rt): the exception vectors are missing");
 
 ASSERT(SIZEOF(.vector_table) > 0x40, "


### PR DESCRIPTION
Force `__reset_vector` and `__eexceptions` symbols to be absolute in linker script assert.

At least `arm-none-eabi-ld` will interpret the symbol location as relative to the section they were defined in. This caused the asserts to fail when `.vector_table` is not placed at memory address 0.