### PR TITLE
Update cortex-m version requirement to allow using 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ r0 = "0.2.2"
 cortex-m-rt-macros = { path = "macros", version = "0.1.5" }
 
 [dev-dependencies]
-cortex-m = "0.5.7"
+cortex-m = ">= 0.5.7, <0.7"
 panic-halt = "0.2.0"
 cortex-m-semihosting = "0.3.1"
 


### PR DESCRIPTION
See also https://github.com/rust-embedded/cortex-m-semihosting/pull/32