### PR TITLE
Remove redundant and incorrect target FPU check

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -73,10 +73,6 @@ handlers.");
         max_int_handlers
     ).unwrap();
 
-    if target.ends_with("-eabihf") {
-        println!("cargo:rustc-cfg=has_fpu");
-    }
-
     println!("cargo:rustc-link-search={}", out.display());
 
     println!("cargo:rerun-if-changed=build.rs");


### PR DESCRIPTION
Most target triples with FPU end in `gnueabihf` or `musleabihf`, so this isn't catching them. Since the `has_fpu` function does, this shouldn't change behavior.