### PR TITLE
do not KEEP the .stack_sizes section

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -131,12 +131,6 @@ SECTIONS
   /* Place the heap right after `.bss` */
   __sheap = ADDR(.bss) + SIZEOF(.bss);
 
-  /* Stack usage metadata emitted by LLVM */
-  .stack_sizes (INFO) :
-  {
-    KEEP(*(.stack_sizes));
-  }
-
   /* ## .got */
   /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
      the input files and raise an error if relocatable code is found */


### PR DESCRIPTION
this undoes PR #118

I found a problem with keeping this section. Turns out that the input
`.stack_sizes` sections contain references to all functions compiled with `-Z
emit-stack-sizes` (the section contains the addresses of all those functions
after all) so keeping those section prevents the linker from removing *any* of
those functions. This is not a problem today because `-Z emit-stack-sizes` is
*opt-in* and only used to analyze a program.

However, I am proposing a rust-lang/rust PR to build the `compiler-builtins`
crate with `-Z emit-stack-sizes`. That change will cause *all* the functions in
that crate to be kept in binaries that link to `cortex-m-rt`, regardless of
whether the crate author uses `-Z emit-stack-sizes` or not, leading a increase
in binary size of about 14 KB (`.text` section).

To prevent issues with that rust-lang/rust PR I propose we undo PR #118. On the
bright side, the tools that were depending on this (`cargo-stack-sizes` and
`cargo-call-stack`) no longer do so in their latest releases so nothing is lost
on the tooling front with this change.

r? @rust-embedded/cortex-m