### PR TITLE
Allow nightly to fail in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 
 matrix:
+  allow_failures:
+    - rust: nightly
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: stable


### PR DESCRIPTION
With nightly being a bit skiddish, lets allow nightly to fail.

Anyone against? @rust-embedded/cortex-m 

- [x] @adamgreig 
- [x] @korken89
- [x] @thejpster
- [ ] @ithinuel 
- [x] @therealprof 