### PR TITLE
add a .uninit section

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -112,7 +112,6 @@ SECTIONS
     __edata = .;
   } > RAM AT > FLASH
 
-
   /* LMA of .data */
   __sidata = LOADADDR(.data);
 
@@ -126,7 +125,15 @@ SECTIONS
     __ebss = .;
   } > RAM
 
-  /* Place the heap right after `.bss` */
+  /* ### .uninit */
+  .uninit (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    *(.uninit .uninit.*);
+    . = ALIGN(4);
+  } > RAM
+
+  /* Place the heap right after `.uninit` */
   . = ALIGN(4);
   __sheap = .;
 


### PR DESCRIPTION
that contains static variables that will not be initialized by the runtime

this implements only the linker section described in RFC #116 so that downstream
libraries / framework can leverage it without (a) forking this crate or (b)
requiring the end user to pass additional linker scripts to the linker when
building their crate.

This commit doesn't add the user interface described in RFC #116; instead it
documents how to use this linker section in the advanced section of the crate
level documentation