### PR TITLE
Feature request: allow custom memory sections in the linker script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,6 +42,10 @@ INCLUDE device.x"#
         f
     };
 
+    // Write an empty `sections.x` file to be overwritten by the application if desired.
+    let mut f_sections = File::create(out.join("sections.x")).unwrap();
+    f_sections.write(b"\n").unwrap();
+
     let max_int_handlers = if target.starts_with("thumbv6m-") {
         println!("cargo:rustc-cfg=cortex_m");
         println!("cargo:rustc-cfg=armv6m");

--- a/link.x.in
+++ b/link.x.in
@@ -145,6 +145,9 @@ SECTIONS
     *(.ARM.exidx.*);
     *(.ARM.extab.*);
   }
+
+  /* User-defined memory sections */
+  INCLUDE sections.x
 }
 
 /* Do not exceed this mark in the error messages below                                    | */

--- a/sections.x
+++ b/sections.x
@@ -1,0 +1,8 @@
+/* Sample sections.x file */
+/* Ensure at least 1KB of RAM is left for heap space. */
+.heap_guard :
+{
+  . = ALIGN(4);
+  . = . + 1K;
+  . = ALIGN(4);
+} > RAM


### PR DESCRIPTION
It looks like the Rust Cortex-M linker script currently expects a `memory.x` file to define the chip's memory regions and a `device.x` file to define weak aliases for each interrupt handler, but I don't see a way to define custom memory sections.

From what I can tell, the `SECTIONS { ... }` part of the linker script assumes that there will only be two main memory regions called `RAM` and `FLASH`, and it places common memory sections like `text`, `bss`, `data`, etc. into those sections.

But some chips have multiple non-contiguous memory banks, and it is not uncommon for applications to split up contiguous memory regions to ensure that important blocks such as caches, heaps, large constant arrays, etc. are placed correctly. For example, you might assign a filesystem cache to a fast block of core-coupled RAM, or you might assign all of your application's constant audio/video data to a known area of Flash memory which the application can configure as read-only.

So, it would be nice if the linker script accepted an optional `sections.x` file where you can define mappings for extra memory sections. I think that this pull request should work, but my 'best effort' testing was not comprehensive and feedback is very welcome.

In order to make the `sections.x` file optional, I added a few lines to the build script which create an empty file with the same name. Suggestions for a better way to do this are welcome, but you can override the empty `sections.x` file using the same sort of build logic that the `cortex_m_quickstart` project uses to populate the `memory.x` file:

    let out_path = PathBuf::from( env::var( "OUT_DIR" ).unwrap() );
    macro_rules! ld_sec { () => { "path/to/your_sections.x" }; };
    File::create( out_path.join( "sections.x" ) )
        .expect( "Failed to open memory sections file" )
        .write_all( include_bytes!( ld_sec!() ) )
        .expect( "Failed to write memory sections file" );
    println!( "cargo:rustc-link-search={}", out_path.display() );