### PR TITLE
Update rand to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ panic-halt = "0.2.0"
 
 [dev-dependencies.rand]
 default-features = false
-version = "0.5.5"
+version = "0.7.0"
+features = ["small_rng"]
 
 [target.'cfg(not(target_os = "none"))'.dev-dependencies]
 compiletest_rs = "0.3.14"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,8 +21,8 @@ features = ["extra-traits", "full"]
 version = "0.15.13"
 
 [dependencies.rand]
-version = "0.5.5"
-default-features = false
+version = "0.7.0"
+features = ["small_rng"]
 
 [dev-dependencies]
 cortex-m-rt = { path = "..", version = "0.6.0" }


### PR DESCRIPTION
Since a bit, `rand` has `small_rng` as a separate feature. I thus had to add it as required feature.