### PR TITLE
Update rand to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ panic-halt = "0.2.0"
 
 [dev-dependencies.rand]
 default-features = false
-version = "0.5.5"
+version = "0.7.0"
 
 [target.'cfg(not(target_os = "none"))'.dev-dependencies]
 compiletest_rs = "0.3.14"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,8 +21,9 @@ features = ["extra-traits", "full"]
 version = "0.15.13"
 
 [dependencies.rand]
-version = "0.5.5"
+version = "0.7.0"
 default-features = false
+features = ["small_rng"]
 
 [dev-dependencies]
 cortex-m-rt = { path = "..", version = "0.6.0" }


### PR DESCRIPTION
This updates the `rand` crate to the latest version 0.7.0.

I've been working on https://github.com/timothyhollabaugh/micromouse, which includes a cargo workspace with both a no_std bin crate for an stm32f4 (`firmware`) and a std bin crate (`simulation`) for running on a normal computer. One of the dependencies in `simulation` depends on `rand` 0.6.5, and  `firmware` depends on `cortex-m-rt-macros` which depends on `rand` 0.5.5. However, due to [issue 645 in the `rand` repo](https://github.com/rust-random/rand/issues/645), having both these versions of `rand` with one being no_std and one std in the dependency tree causes compile errors. Hence the upgrade to 0.7.0.

Everything builds, and I have tested it with the uart isr in the above repo.