### PR TITLE
Enable building semihosting for Armv8m

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,10 @@ autoexamples = true
 r0 = "0.2.2"
 cortex-m-rt-macros = { path = "macros", version = "0.1.5" }
 
-[target.thumbv7em-none-eabihf.dev-dependencies]
-cortex-m-semihosting = "0.3.1"
-
-[target.thumbv7em-none-eabi.dev-dependencies]
-cortex-m-semihosting = "0.3.1"
-
-[target.thumbv7m-none-eabi.dev-dependencies]
-cortex-m-semihosting = "0.3.1"
-
-[target.thumbv6m-none-eabi.dev-dependencies]
-cortex-m-semihosting = "0.3.1"
-
 [dev-dependencies]
 cortex-m = "0.6"
 panic-halt = "0.2.0"
+cortex-m-semihosting = "0.3"
 
 [dev-dependencies.rand]
 default-features = false

--- a/examples/qemu.rs
+++ b/examples/qemu.rs
@@ -2,11 +2,8 @@
 #![no_main]
 #![no_std]
 
-
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
-
-#[cfg(not(armv8m))]
 extern crate cortex_m_semihosting as semihosting;
 
 extern crate panic_halt;
@@ -14,7 +11,6 @@ extern crate panic_halt;
 use cortex_m::asm;
 use rt::entry;
 
-#[cfg(not(armv8m))]
 #[entry]
 fn main() -> ! {
     use core::fmt::Write;
@@ -28,13 +24,5 @@ fn main() -> ! {
         write!(hstdout, "x = {}\n", x).unwrap();
         // exit from qemu
         semihosting::debug::exit(semihosting::debug::EXIT_SUCCESS);
-    }
-}
-
-#[cfg(armv8m)]
-#[entry]
-fn main() -> ! {
-    loop {
-        asm::nop();
     }
 }


### PR DESCRIPTION
Semihosting protocol has not changed for Arvmv8m and hence it
need not be disabled for this architecture. 