### PR TITLE
Document a possible reason for the 'interrupt vectors are missing' error

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -191,6 +191,7 @@ ASSERT(SIZEOF(.vector_table) > 0x40, "
 ERROR(cortex-m-rt): The interrupt vectors are missing.
 Possible solutions, from most likely to less likely:
 - Link to a svd2rust generated device crate
+- Check that you actually use the device/hal/bsp crate in your code
 - Disable the 'device' feature of cortex-m-rt to build a generic application (a dependency
 may be enabling it)
 - Supply the interrupt handlers yourself. Check the documentation for details.");


### PR DESCRIPTION
This error happens when you have all the needed dependencies in Cargo.toml but do not use them yet in main.rs. Due to the fact that you already "have" a "svd2rust generated device crate", this error is quite confusing.