### PR TITLE
Make `ExceptionFrame`s fields private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,33 +416,60 @@ pub use macros::{entry, exception, pre_init};
 #[doc(hidden)]
 pub static __ONCE__: () = ();
 
-/// Registers stacked (pushed into the stack) during an exception
+/// Registers stacked (pushed into the stack) during an exception.
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct ExceptionFrame {
-    /// (General purpose) Register 0
-    pub r0: u32,
+    r0: u32,
+    r1: u32,
+    r2: u32,
+    r3: u32,
+    r12: u32,
+    lr: u32,
+    pc: u32,
+    xpsr: u32,
+}
 
-    /// (General purpose) Register 1
-    pub r1: u32,
+impl ExceptionFrame {
+    /// Returns the value of (general purpose) register 0.
+    pub fn r0(&self) -> u32 {
+        self.r0
+    }
 
-    /// (General purpose) Register 2
-    pub r2: u32,
+    /// Returns the value of (general purpose) register 1.
+    pub fn r1(&self) -> u32 {
+        self.r1
+    }
 
-    /// (General purpose) Register 3
-    pub r3: u32,
+    /// Returns the value of (general purpose) register 2.
+    pub fn r2(&self) -> u32 {
+        self.r2
+    }
 
-    /// (General purpose) Register 12
-    pub r12: u32,
+    /// Returns the value of (general purpose) register 3.
+    pub fn r3(&self) -> u32 {
+        self.r3
+    }
 
-    /// Linker Register
-    pub lr: u32,
+    /// Returns the value of (general purpose) register 12.
+    pub fn r12(&self) -> u32 {
+        self.r12
+    }
 
-    /// Program Counter
-    pub pc: u32,
+    /// Returns the value of the Link Register.
+    pub fn lr(&self) -> u32 {
+        self.lr
+    }
 
-    /// Program Status Register
-    pub xpsr: u32,
+    /// Returns the value of the Program Counter.
+    pub fn pc(&self) -> u32 {
+        self.pc
+    }
+
+    /// Returns the value of the Program Status Register.
+    pub fn xpsr(&self) -> u32 {
+        self.xpsr
+    }
 }
 
 impl fmt::Debug for ExceptionFrame {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,41 +472,81 @@ impl ExceptionFrame {
     }
 
     /// Sets the stacked value of (general purpose) register 0.
+    ///
+    /// # Safety
+    ///
+    /// This affects the `r0` register of the preempted code, which must not rely on it getting
+    /// restored to its previous value.
     pub unsafe fn set_r0(&mut self, value: u32) {
         self.r0 = value;
     }
 
     /// Sets the stacked value of (general purpose) register 1.
+    ///
+    /// # Safety
+    ///
+    /// This affects the `r1` register of the preempted code, which must not rely on it getting
+    /// restored to its previous value.
     pub unsafe fn set_r1(&mut self, value: u32) {
         self.r1 = value;
     }
 
     /// Sets the stacked value of (general purpose) register 2.
+    ///
+    /// # Safety
+    ///
+    /// This affects the `r2` register of the preempted code, which must not rely on it getting
+    /// restored to its previous value.
     pub unsafe fn set_r2(&mut self, value: u32) {
         self.r2 = value;
     }
 
     /// Sets the stacked value of (general purpose) register 3.
+    ///
+    /// # Safety
+    ///
+    /// This affects the `r3` register of the preempted code, which must not rely on it getting
+    /// restored to its previous value.
     pub unsafe fn set_r3(&mut self, value: u32) {
         self.r3 = value;
     }
 
     /// Sets the stacked value of (general purpose) register 12.
+    ///
+    /// # Safety
+    ///
+    /// This affects the `r12` register of the preempted code, which must not rely on it getting
+    /// restored to its previous value.
     pub unsafe fn set_r12(&mut self, value: u32) {
         self.r12 = value;
     }
 
     /// Sets the stacked value of the Link Register.
+    ///
+    /// # Safety
+    ///
+    /// This affects the `lr` register of the preempted code, which must not rely on it getting
+    /// restored to its previous value.
     pub unsafe fn set_lr(&mut self, value: u32) {
         self.lr = value;
     }
 
     /// Sets the stacked value of the Program Counter.
+    ///
+    /// # Safety
+    ///
+    /// This affects the `pc` register of the preempted code, which must not rely on it getting
+    /// restored to its previous value.
     pub unsafe fn set_pc(&mut self, value: u32) {
         self.pc = value;
     }
 
     /// Sets the stacked value of the Program Status Register.
+    ///
+    /// # Safety
+    ///
+    /// This affects the `xPSR` registers (`IPSR`, `APSR`, and `EPSR`) of the preempted code, which
+    /// must not rely on them getting restored to their previous value.
     pub unsafe fn set_xpsr(&mut self, value: u32) {
         self.xpsr = value;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,7 @@ pub use macros::{entry, exception, pre_init};
 #[doc(hidden)]
 pub static __ONCE__: () = ();
 
-/// Registers stacked (pushed into the stack) during an exception.
+/// Registers stacked (pushed onto the stack) during an exception.
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct ExceptionFrame {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,6 +470,46 @@ impl ExceptionFrame {
     pub fn xpsr(&self) -> u32 {
         self.xpsr
     }
+
+    /// Sets the stacked value of (general purpose) register 0.
+    pub unsafe fn set_r0(&mut self, value: u32) {
+        self.r0 = value;
+    }
+
+    /// Sets the stacked value of (general purpose) register 1.
+    pub unsafe fn set_r1(&mut self, value: u32) {
+        self.r1 = value;
+    }
+
+    /// Sets the stacked value of (general purpose) register 2.
+    pub unsafe fn set_r2(&mut self, value: u32) {
+        self.r2 = value;
+    }
+
+    /// Sets the stacked value of (general purpose) register 3.
+    pub unsafe fn set_r3(&mut self, value: u32) {
+        self.r3 = value;
+    }
+
+    /// Sets the stacked value of (general purpose) register 12.
+    pub unsafe fn set_r12(&mut self, value: u32) {
+        self.r12 = value;
+    }
+
+    /// Sets the stacked value of the Link Register.
+    pub unsafe fn set_lr(&mut self, value: u32) {
+        self.lr = value;
+    }
+
+    /// Sets the stacked value of the Program Counter.
+    pub unsafe fn set_pc(&mut self, value: u32) {
+        self.pc = value;
+    }
+
+    /// Sets the stacked value of the Program Status Register.
+    pub unsafe fn set_xpsr(&mut self, value: u32) {
+        self.xpsr = value;
+    }
 }
 
 impl fmt::Debug for ExceptionFrame {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,41 +432,49 @@ pub struct ExceptionFrame {
 
 impl ExceptionFrame {
     /// Returns the value of (general purpose) register 0.
+    #[inline(always)]
     pub fn r0(&self) -> u32 {
         self.r0
     }
 
     /// Returns the value of (general purpose) register 1.
+    #[inline(always)]
     pub fn r1(&self) -> u32 {
         self.r1
     }
 
     /// Returns the value of (general purpose) register 2.
+    #[inline(always)]
     pub fn r2(&self) -> u32 {
         self.r2
     }
 
     /// Returns the value of (general purpose) register 3.
+    #[inline(always)]
     pub fn r3(&self) -> u32 {
         self.r3
     }
 
     /// Returns the value of (general purpose) register 12.
+    #[inline(always)]
     pub fn r12(&self) -> u32 {
         self.r12
     }
 
     /// Returns the value of the Link Register.
+    #[inline(always)]
     pub fn lr(&self) -> u32 {
         self.lr
     }
 
     /// Returns the value of the Program Counter.
+    #[inline(always)]
     pub fn pc(&self) -> u32 {
         self.pc
     }
 
     /// Returns the value of the Program Status Register.
+    #[inline(always)]
     pub fn xpsr(&self) -> u32 {
         self.xpsr
     }
@@ -477,6 +485,7 @@ impl ExceptionFrame {
     ///
     /// This affects the `r0` register of the preempted code, which must not rely on it getting
     /// restored to its previous value.
+    #[inline(always)]
     pub unsafe fn set_r0(&mut self, value: u32) {
         self.r0 = value;
     }
@@ -487,6 +496,7 @@ impl ExceptionFrame {
     ///
     /// This affects the `r1` register of the preempted code, which must not rely on it getting
     /// restored to its previous value.
+    #[inline(always)]
     pub unsafe fn set_r1(&mut self, value: u32) {
         self.r1 = value;
     }
@@ -497,6 +507,7 @@ impl ExceptionFrame {
     ///
     /// This affects the `r2` register of the preempted code, which must not rely on it getting
     /// restored to its previous value.
+    #[inline(always)]
     pub unsafe fn set_r2(&mut self, value: u32) {
         self.r2 = value;
     }
@@ -507,6 +518,7 @@ impl ExceptionFrame {
     ///
     /// This affects the `r3` register of the preempted code, which must not rely on it getting
     /// restored to its previous value.
+    #[inline(always)]
     pub unsafe fn set_r3(&mut self, value: u32) {
         self.r3 = value;
     }
@@ -517,6 +529,7 @@ impl ExceptionFrame {
     ///
     /// This affects the `r12` register of the preempted code, which must not rely on it getting
     /// restored to its previous value.
+    #[inline(always)]
     pub unsafe fn set_r12(&mut self, value: u32) {
         self.r12 = value;
     }
@@ -527,6 +540,7 @@ impl ExceptionFrame {
     ///
     /// This affects the `lr` register of the preempted code, which must not rely on it getting
     /// restored to its previous value.
+    #[inline(always)]
     pub unsafe fn set_lr(&mut self, value: u32) {
         self.lr = value;
     }
@@ -537,6 +551,7 @@ impl ExceptionFrame {
     ///
     /// This affects the `pc` register of the preempted code, which must not rely on it getting
     /// restored to its previous value.
+    #[inline(always)]
     pub unsafe fn set_pc(&mut self, value: u32) {
         self.pc = value;
     }
@@ -547,6 +562,7 @@ impl ExceptionFrame {
     ///
     /// This affects the `xPSR` registers (`IPSR`, `APSR`, and `EPSR`) of the preempted code, which
     /// must not rely on them getting restored to their previous value.
+    #[inline(always)]
     pub unsafe fn set_xpsr(&mut self, value: u32) {
         self.xpsr = value;
     }


### PR DESCRIPTION
Closes #234

~~I can also add the `unsafe` setters, but they don't have any use right now.~~ (added them in order to not regress available operations on `ExceptionFrame`)