### PR TITLE
Run CI on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,12 +63,6 @@ script:
 
 after_script: set +e
 
-branches:
-  only:
-    - master
-    - staging
-    - trying
-
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
This is useful for testing branches of old versions that are still maintained (eg. `v0.6.x` here).

Maintainers are encouraged to open PRs from their forks instead of branches in this repo to prevent CI from running twice. I think switching to GitHub Actions would also prevent this if I'm not mistaken (Travis is a bit weird here, there's no point in running the same pipeline twice).