### PR TITLE
Ignore a doctest again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@
 //! must contain build script that puts `device.x` somewhere the linker can find. An example of such
 //! build script is shown below:
 //!
-//! ```no_ruin
+//! ```ignore
 //! use std::env;
 //! use std::fs::File;
 //! use std::io::Write;


### PR DESCRIPTION
I accidentally typoed `no_run`, but compiling the test fails since the
`device.x` path is wrong. I don't think this can be fixed, so ignore the
test instead.

The effect is the same as before but now the block gets highlighted again.