### PR TITLE
New compile-fail string for interrupt-invalid

### DIFF
--- a/tests/compile-fail/interrupt-invalid.rs
+++ b/tests/compile-fail/interrupt-invalid.rs
@@ -19,4 +19,4 @@ enum interrupt {
 // NOTE this looks a bit better when using a device crate:
 // "no variant named `foo` found for type `stm32f30x::Interrupt` in the current scope"
 #[interrupt]
-fn foo() {} //~ ERROR no variant or associated item named `foo` found for type `interrupt` in the current scope
+fn foo() {} //~ ERROR no variant or associated item named `foo` found for enum `interrupt` in the current scope [E0599]


### PR DESCRIPTION
There was a change in the error string