### PR TITLE
Add testing linker=arm-none-eabi-gcc and MSRV to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,53 +4,62 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
+    # MSRV 1.32.0 #############################################################
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: 1.32.0
+
+    - env: TARGET=thumbv6m-none-eabi
+      rust: 1.32.0
+
+    - env: TARGET=thumbv7m-none-eabi
+      rust: 1.32.0
+
+    - env: TARGET=thumbv7em-none-eabi
+      rust: 1.32.0
+
+    - env: TARGET=thumbv7em-none-eabihf
+      rust: 1.32.0
+
+    - env: TARGET=thumbv8m.main-none-eabi
+      rust: 1.32.0
+
+    # Stable ##################################################################
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: stable
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv6m-none-eabi
       rust: stable
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7m-none-eabi
       rust: stable
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabi
       rust: stable
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabihf
       rust: stable
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv8m.main-none-eabi
       rust: stable
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
+    # Nightly #################################################################
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: nightly
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv6m-none-eabi
       rust: nightly
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7m-none-eabi
       rust: nightly
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabi
       rust: nightly
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7em-none-eabihf
       rust: nightly
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv8m.main-none-eabi
       rust: nightly
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
 before_install: set -e
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,24 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-    # MSRV 1.32.0 #############################################################
+    # MSRV 1.39.0 #############################################################
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.32.0
+      rust: 1.39.0
 
     - env: TARGET=thumbv6m-none-eabi
-      rust: 1.32.0
+      rust: 1.39.0
 
     - env: TARGET=thumbv7m-none-eabi
-      rust: 1.32.0
+      rust: 1.39.0
 
     - env: TARGET=thumbv7em-none-eabi
-      rust: 1.32.0
+      rust: 1.39.0
 
     - env: TARGET=thumbv7em-none-eabihf
-      rust: 1.32.0
+      rust: 1.39.0
 
     - env: TARGET=thumbv8m.main-none-eabi
-      rust: 1.32.0
+      rust: 1.39.0
 
     # Stable ##################################################################
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -57,6 +57,28 @@ main() {
         cargo rustc --target "$TARGET" --example device --features device --release -- \
               -C linker=arm-none-eabi-ld
 
+        # linking with GNU GCC
+        for ex in "${examples[@]}"; do
+            cargo rustc --target "$TARGET" --example "$ex" -- \
+                  -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
+
+            cargo rustc --target "$TARGET" --example "$ex" --release -- \
+                  -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
+        done
+        for ex in "${fail_examples[@]}"; do
+            ! cargo rustc --target "$TARGET" --example "$ex" -- \
+                  -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
+
+            ! cargo rustc --target "$TARGET" --example "$ex" --release -- \
+                  -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
+        done
+
+        cargo rustc --target "$TARGET" --example device --features device -- \
+              -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
+
+        cargo rustc --target "$TARGET" --example device --features device --release -- \
+              -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
+
         # linking with rustc's LLD
         for ex in "${examples[@]}"; do
             cargo rustc --target "$TARGET" --example "$ex"
@@ -76,6 +98,10 @@ main() {
             # linking with GNU LD
             env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" cargo run --target "$TARGET" --example qemu | grep "x = 42"
             env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" cargo run --target "$TARGET" --example qemu --release | grep "x = 42"
+
+            # linking with GNU GCC
+            env RUSTFLAGS="-C linker=arm-none-eabi-gcc -C link-arg=-Tlink.x -Clink-arg=-nostartfiles" cargo run --target "$TARGET" --example qemu | grep "x = 42"
+            env RUSTFLAGS="-C linker=arm-none-eabi-gcc -C link-arg=-Tlink.x -Clink-arg=-nostartfiles" cargo run --target "$TARGET" --example qemu --release | grep "x = 42"
 
             # linking with rustc's LLD
             cargo run --target "$TARGET" --example qemu | grep "x = 42"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -32,80 +32,40 @@ main() {
     local fail_examples=(
         data_overflow
     )
+    local linkers=(
+        # Link with arm-none-eabi-ld
+        "-C linker=arm-none-eabi-ld"
+        # Link with arm-none-eabi-gcc, requires -nostartfiles
+        "-C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles"
+        # Link with rust-lld (default)
+        ""
+    )
     if [ "$TARGET" != x86_64-unknown-linux-gnu ]; then
         RUSTDOCFLAGS="-Cpanic=abort" cargo test --doc
 
-        # linking with GNU LD
-        for ex in "${examples[@]}"; do
-            cargo rustc --target "$TARGET" --example "$ex" -- \
-                  -C linker=arm-none-eabi-ld
-
-            cargo rustc --target "$TARGET" --example "$ex" --release -- \
-                  -C linker=arm-none-eabi-ld
+        for linker in "${linkers[@]}"; do
+            for ex in "${examples[@]}"; do
+                cargo rustc --target "$TARGET" --example "$ex" -- $linker
+                cargo rustc --target "$TARGET" --example "$ex" --release -- $linker
+            done
+            for ex in "${fail_examples[@]}"; do
+                ! cargo rustc --target "$TARGET" --example "$ex" -- $linker
+                ! cargo rustc --target "$TARGET" --example "$ex" --release -- $linker
+            done
+            cargo rustc --target "$TARGET" --example device --features device -- $linker
+            cargo rustc --target "$TARGET" --example device --features device --release -- $linker
         done
-        for ex in "${fail_examples[@]}"; do
-            ! cargo rustc --target "$TARGET" --example "$ex" -- \
-                  -C linker=arm-none-eabi-ld
-
-            ! cargo rustc --target "$TARGET" --example "$ex" --release -- \
-                  -C linker=arm-none-eabi-ld
-        done
-
-        cargo rustc --target "$TARGET" --example device --features device -- \
-              -C linker=arm-none-eabi-ld
-
-        cargo rustc --target "$TARGET" --example device --features device --release -- \
-              -C linker=arm-none-eabi-ld
-
-        # linking with GNU GCC
-        for ex in "${examples[@]}"; do
-            cargo rustc --target "$TARGET" --example "$ex" -- \
-                  -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
-
-            cargo rustc --target "$TARGET" --example "$ex" --release -- \
-                  -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
-        done
-        for ex in "${fail_examples[@]}"; do
-            ! cargo rustc --target "$TARGET" --example "$ex" -- \
-                  -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
-
-            ! cargo rustc --target "$TARGET" --example "$ex" --release -- \
-                  -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
-        done
-
-        cargo rustc --target "$TARGET" --example device --features device -- \
-              -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
-
-        cargo rustc --target "$TARGET" --example device --features device --release -- \
-              -C linker=arm-none-eabi-gcc -C link-arg=-nostartfiles
-
-        # linking with rustc's LLD
-        for ex in "${examples[@]}"; do
-            cargo rustc --target "$TARGET" --example "$ex"
-            cargo rustc --target "$TARGET" --example "$ex" --release
-        done
-        for ex in "${fail_examples[@]}"; do
-            ! cargo rustc --target "$TARGET" --example "$ex"
-            ! cargo rustc --target "$TARGET" --example "$ex" --release
-        done
-
-        cargo rustc --target "$TARGET" --example device --features device
-        cargo rustc --target "$TARGET" --example device --features device --release
     fi
 
     case $TARGET in
         thumbv6m-none-eabi|thumbv7m-none-eabi)
-            # linking with GNU LD
-            env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" cargo run --target "$TARGET" --example qemu | grep "x = 42"
-            env RUSTFLAGS="-C linker=arm-none-eabi-ld -C link-arg=-Tlink.x" cargo run --target "$TARGET" --example qemu --release | grep "x = 42"
+            for linker in "${linkers[@]}"; do
+                env RUSTFLAGS="$linker -C link-arg=-Tlink.x" cargo run \
+                    --target "$TARGET" --example qemu | grep "x = 42"
+                env RUSTFLAGS="$linker -C link-arg=-Tlink.x" cargo run \
+                    --target "$TARGET" --example qemu --release | grep "x = 42"
+            done
 
-            # linking with GNU GCC
-            env RUSTFLAGS="-C linker=arm-none-eabi-gcc -C link-arg=-Tlink.x -Clink-arg=-nostartfiles" cargo run --target "$TARGET" --example qemu | grep "x = 42"
-            env RUSTFLAGS="-C linker=arm-none-eabi-gcc -C link-arg=-Tlink.x -Clink-arg=-nostartfiles" cargo run --target "$TARGET" --example qemu --release | grep "x = 42"
-
-            # linking with rustc's LLD
-            cargo run --target "$TARGET" --example qemu | grep "x = 42"
-            cargo run --target "$TARGET" --example qemu --release | grep "x = 42"
             ;;
     esac
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,6 +388,10 @@
 //! [attr-entry]: attr.entry.html
 //! [attr-exception]: attr.exception.html
 //! [attr-pre_init]: attr.pre_init.html
+//!
+//! # Minimum Supported Rust Version (MSRV)
+//!
+//! The MSRV of this release is Rust 1.32.0.
 
 // # Developer notes
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,7 @@
 //! [`MaybeUninit`]: https://doc.rust-lang.org/core/mem/union.MaybeUninit.html
 //!
 //! ```no_run,edition2018
+//! # extern crate core;
 //! use core::mem::MaybeUninit;
 //!
 //! const STACK_SIZE: usize = 8 * 1024;
@@ -391,7 +392,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! The MSRV of this release is Rust 1.32.0.
+//! The MSRV of this release is Rust 1.39.0.
 
 // # Developer notes
 //


### PR DESCRIPTION
Replacing #260.

This PR extends our current tests with `linker=rust-lld` and `linker=arm-none-eabi-ld` to include `linker=arm-none-eabi-gcc`, since those options are all included in our example [`.cargo/config`](https://github.com/rust-embedded/cortex-m-rt/blob/master/.cargo/config). It looks like another linker only adds a handful of seconds to CI, since most time is spent building dependencies once.

It also adds a test with Rust 1.32.0 to the CI as a candidate MSRV. Building with 1.31.0 fails because of the dev-dependency on cortex-m-semihosting 0.3.5:

```
error[E0658]: using the `?` macro Kleene operator for "at most one" repetition is unstable (see issue #48075)
   --> /home/adam/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-semihosting-0.3.5/src/macros.rs:111:25
    |
111 |     ($($val:expr),+ $(,)?) => {
    |                         ^

error: expected `*` or `+`
```
That's just a test error which end users wouldn't experience, so we could consider making 1.31.0 the MSRV and working around the c-m-semihosting issue. I don't know if there are other 1.31.0 issues.

Finally the PR removes the travis check preventing builds on pushes to master. In principle we know that builds to master succeed because bors tests them before pushing, so adding the extra check mostly means we get a well-defined build status from Travis for flags etc. The build times for cortex-m-rt (around 3min overall) are a bit longer than r0 (where we did the same thing), so we could just run a minimal test here instead. I don't think it's a significant overhead given how infrequently we push to master, though.