### PR TITLE
link.x: .bss should be NOLOAD

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -119,7 +119,7 @@ SECTIONS
   __sidata = LOADADDR(.data);
 
   /* ### .bss */
-  .bss : ALIGN(4)
+  .bss (NOLOAD) : ALIGN(4)
   {
     . = ALIGN(4);
     __sbss = .;


### PR DESCRIPTION
Previously, this linker script was producing an ELF PHDR marked LOAD for
the .bss section, which suggested to tools like OpenOCD that something
needed to be copied into RAM during flashing. This section happened to
have filesz=0 in practice, so only extra bookkeeping work was done and
not extra transfers. We noticed this when tracking down an odd behavior
in one of our ELF post-processing tools.

With this change, the linker script no longer emits a LOAD PHDR.