### PR TITLE
Get rid of #[deny(warnings)]

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! Do not use this crate directly.
 
-#![deny(warnings)]
-
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,6 @@
 // here will appear in the linker script (`link.x`) in conjunction with the `KEEP` command.
 
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![no_std]
 
 extern crate cortex_m_rt_macros as macros;


### PR DESCRIPTION
This is considered harmful as the warnings may change with any compiler
release.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>