### PR TITLE
Replace __ONCE__ with Cargo links key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m-rt"
 version = "0.6.11"
 autoexamples = true
+links = "cortex-m-rt" # Prevent multiple versions of cortex-m-rt being linked
 
 [dependencies]
 r0 = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,6 +689,14 @@ pub use macros::exception;
 /// [rfc1414]: https://github.com/rust-lang/rfcs/blob/master/text/1414-rvalue_static_promotion.md
 pub use macros::pre_init;
 
+// We export this static with an informative name so that if an application attempts to link
+// two copies of cortex-m-rt together, linking will fail. We also declare a links key in
+// Cargo.toml which is the more modern way to solve the same problem, but we have to keep
+// __ONCE__ around to prevent linking with versions before the links key was added.
+#[export_name = "error: cortex-m-rt appears more than once in the dependency graph"]
+#[doc(hidden)]
+pub static __ONCE__: () = ();
+
 /// Registers stacked (pushed onto the stack) during an exception.
 #[derive(Clone, Copy)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,10 +689,6 @@ pub use macros::exception;
 /// [rfc1414]: https://github.com/rust-lang/rfcs/blob/master/text/1414-rvalue_static_promotion.md
 pub use macros::pre_init;
 
-#[export_name = "error: cortex-m-rt appears more than once in the dependency graph"]
-#[doc(hidden)]
-pub static __ONCE__: () = ();
-
 /// Registers stacked (pushed onto the stack) during an exception.
 #[derive(Clone, Copy)]
 #[repr(C)]


### PR DESCRIPTION
This would fix #275. We use the links key in cortex-m already [here](https://github.com/rust-embedded/cortex-m/blob/master/Cargo.toml#L16). See also https://github.com/rust-embedded/wg/issues/467.