### PR TITLE
Add barriers after FPU enabling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ links = "cortex-m-rt" # Prevent multiple versions of cortex-m-rt being linked
 [dependencies]
 r0 = "1.0"
 cortex-m-rt-macros = { path = "macros", version = "=0.6.11" }
+cortex-m = "0.6"
 
 [dev-dependencies]
-cortex-m = "0.6"
 panic-halt = "0.2.0"
 cortex-m-semihosting = "0.3"
 


### PR DESCRIPTION
This only seems to be required for M7 cores, but since we can't know the specific core, we can't filter on that.

I thought about using the SCB's `RegisterBlock` from cortex-m to enable the FPU, but the [registers](https://docs.rs/cortex-m/0.6.2/cortex_m/peripheral/scb/struct.RegisterBlock.html) are just the generics `RW` which isn't that different from what we're doing right now, and we would need `Peripherals::steal` to use the methods from SCB which would set the `CORE_PERIPHERALS`/`TAKEN` flag.

And one question, with this change, can we get rid of the `trampoline()` function? I don't think the compiler will do reordering across foreign functions calls (dsb/isb), but I might be missing something.