### PR TITLE
Make Vector public in interrupt example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@
 //! IRQ number = 2, and `Bar`, with IRQ number = 4.
 //!
 //! ```no_run
-//! union Vector {
+//! pub union Vector {
 //!     handler: unsafe extern "C" fn(),
 //!     reserved: usize,
 //! }


### PR DESCRIPTION
If the `Vector`union is not public, the example code leads to a compilation error because `pub static __INTERRUPTS` leaks the private type `Vector`.