### PR TITLE
Fix possible overflow of .data region in FLASH

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -106,14 +106,14 @@ SECTIONS
 
   /* ## Sections in RAM */
   /* ### .data */
-  .data : AT(__erodata) ALIGN(4)
+  .data : ALIGN(4)
   {
     . = ALIGN(4);
     __sdata = .;
     *(.data .data.*);
     . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
     __edata = .;
-  } > RAM
+  } > RAM AT>FLASH
 
   /* LMA of .data */
   __sidata = LOADADDR(.data);


### PR DESCRIPTION
Hi,

i found a bug on the size checking of the FLASH region, that in some cases allows it to be larger than it's defined size.
This happens because the .data section is placed on a FLASH address (at the end of __erodata) but it's not checked against the FLASH region size.
Changing the section as shown solves the issue.