### PR TITLE
Fix common uses of INSERT AFTER with .bss and .text

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -102,8 +102,9 @@ SECTIONS
        This is required by LLD to ensure the LMA of the following .data
        section will have the correct alignment. */
     . = ALIGN(4);
-    __erodata = .;
   } > FLASH
+  . = ALIGN(4); /* Ensure __erodata is aligned if something unaligned is inserted after .rodata */
+  __erodata = .;
 
   /* ## Sections in RAM */
   /* ### .data */
@@ -113,8 +114,9 @@ SECTIONS
     __sdata = .;
     *(.data .data.*);
     . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
-    __edata = .;
   } > RAM AT>FLASH
+  . = ALIGN(4); /* Ensure __edata is aligned if something unaligned is inserted after .data */
+  __edata = .;
 
   /* LMA of .data */
   __sidata = LOADADDR(.data);

--- a/link.x.in
+++ b/link.x.in
@@ -88,9 +88,9 @@ SECTIONS
     *(.text .text.*);
     *(.HardFaultTrampoline);
     *(.HardFault.*);
-    . = ALIGN(4);
-    __etext = .;
   } > FLASH
+  . = ALIGN(4);
+  __etext = .; /* Define outside of .text to allow using INSERT AFTER .text */
 
   /* ### .rodata */
   .rodata __etext : ALIGN(4)
@@ -119,14 +119,15 @@ SECTIONS
   __sidata = LOADADDR(.data);
 
   /* ### .bss */
+  . = ALIGN(4);
+  __sbss = .; /* Define outside of section to include INSERT BEFORE/AFTER symbols */
   .bss (NOLOAD) : ALIGN(4)
   {
-    . = ALIGN(4);
-    __sbss = .;
     *(.bss .bss.*);
-    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
-    __ebss = .;
+    *(COMMON); /* Uninitialized C statics */
   } > RAM
+  . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+  __ebss = .;
 
   /* ### .uninit */
   .uninit (NOLOAD) : ALIGN(4)

--- a/link.x.in
+++ b/link.x.in
@@ -88,8 +88,9 @@ SECTIONS
     *(.text .text.*);
     *(.HardFaultTrampoline);
     *(.HardFault.*);
+    . = ALIGN(4); /* Pad .text to the alignment to workaround overlapping load section bug in old lld */
   } > FLASH
-  . = ALIGN(4);
+  . = ALIGN(4); /* Ensure __etext is aligned if something unaligned is inserted after .text */
   __etext = .; /* Define outside of .text to allow using INSERT AFTER .text */
 
   /* ### .rodata */
@@ -125,8 +126,9 @@ SECTIONS
   {
     *(.bss .bss.*);
     *(COMMON); /* Uninitialized C statics */
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
   } > RAM
-  . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+  . = ALIGN(4); /* Ensure __ebss is aligned if something unaligned is inserted after .bss */
   __ebss = .;
 
   /* ### .uninit */


### PR DESCRIPTION
Fixes #267 
Fixes #266

This fixes two related issues.

1. Named sections are often inserted after `.bss` or `.text` in order to have them handled as if they were part of that section. Defining the start/end symbols outside of the section allows this to work.
2. Uninitialized C statics will end up as common symbols which end up in the COMMON input section. If this section is orphaned, it will likely end up placed after `.bss`. C code often expects these statics to be zero initialized. The first change would cause these symbols to be placed before `__ebss` so they will get zeroed by the reset handler. Explicitly placing the common symbols into `.bss` ensures this happens. Users who want uninitialized symbols should use the `.uninit` section.

See https://github.com/rust-embedded/cortex-m-rt/pull/287#issuecomment-677743856