### PR TITLE
Make it unsafe to define NMI handlers

### DIFF
--- a/examples/divergent-default-handler.rs
+++ b/examples/divergent-default-handler.rs
@@ -1,4 +1,3 @@
-#![deny(unsafe_code)]
 #![deny(warnings)]
 #![no_main]
 #![no_std]
@@ -14,6 +13,6 @@ fn foo() -> ! {
 }
 
 #[exception]
-fn DefaultHandler(_irqn: i16) -> ! {
+unsafe fn DefaultHandler(_irqn: i16) -> ! {
     loop {}
 }

--- a/examples/override-exception.rs
+++ b/examples/override-exception.rs
@@ -1,6 +1,5 @@
 //! How to override the hard fault exception handler and the default exception handler
 
-#![deny(unsafe_code)]
 #![deny(warnings)]
 #![no_main]
 #![no_std]
@@ -18,12 +17,12 @@ fn main() -> ! {
 }
 
 #[exception]
-fn DefaultHandler(_irqn: i16) {
+unsafe fn DefaultHandler(_irqn: i16) {
     asm::bkpt();
 }
 
 #[exception]
-fn HardFault(_ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(_ef: &ExceptionFrame) -> ! {
     asm::bkpt();
 
     loop {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,29 +657,13 @@ pub use macros::entry;
 ///
 /// # Examples
 ///
-/// - Setting the `HardFault` handler
-///
-/// ```
-/// # extern crate cortex_m_rt;
-/// # extern crate cortex_m_rt_macros;
-/// use cortex_m_rt::{ExceptionFrame, exception};
-///
-/// #[exception]
-/// fn HardFault(ef: &ExceptionFrame) -> ! {
-///     // prints the exception frame as a panic message
-///     panic!("{:#?}", ef);
-/// }
-///
-/// # fn main() {}
-/// ```
-///
 /// - Setting the default handler
 ///
 /// ```
 /// use cortex_m_rt::exception;
 ///
 /// #[exception]
-/// fn DefaultHandler(irqn: i16) {
+/// unsafe fn DefaultHandler(irqn: i16) {
 ///     println!("IRQn = {}", irqn);
 /// }
 ///

--- a/tests/compile-fail/default-handler-bad-signature-1.rs
+++ b/tests/compile-fail/default-handler-bad-signature-1.rs
@@ -12,5 +12,5 @@ fn foo() -> ! {
 }
 
 #[exception]
-fn DefaultHandler(_irqn: i16, undef: u32) {}
-//~^ ERROR `DefaultHandler` must have signature `[unsafe] fn(i16) [-> !]`
+unsafe fn DefaultHandler(_irqn: i16, undef: u32) {}
+//~^ ERROR `DefaultHandler` must have signature `unsafe fn(i16) [-> !]`

--- a/tests/compile-fail/default-handler-bad-signature-2.rs
+++ b/tests/compile-fail/default-handler-bad-signature-2.rs
@@ -12,7 +12,7 @@ fn foo() -> ! {
 }
 
 #[exception]
-fn DefaultHandler(_irqn: i16) -> u32 {
-    //~^ ERROR `DefaultHandler` must have signature `[unsafe] fn(i16) [-> !]`
+unsafe fn DefaultHandler(_irqn: i16) -> u32 {
+    //~^ ERROR `DefaultHandler` must have signature `unsafe fn(i16) [-> !]`
     0
 }

--- a/tests/compile-fail/default-handler-hidden.rs
+++ b/tests/compile-fail/default-handler-hidden.rs
@@ -18,5 +18,5 @@ mod hidden {
     use cortex_m_rt::exception;
 
     #[exception]
-    fn DefaultHandler(_irqn: i16) {}
+    unsafe fn DefaultHandler(_irqn: i16) {}
 }

--- a/tests/compile-fail/default-handler-twice.rs
+++ b/tests/compile-fail/default-handler-twice.rs
@@ -12,11 +12,11 @@ fn foo() -> ! {
 }
 
 #[exception]
-fn DefaultHandler(_irqn: i16) {}
+unsafe fn DefaultHandler(_irqn: i16) {}
 
 pub mod reachable {
     use cortex_m_rt::exception;
 
     #[exception] //~ ERROR symbol `DefaultHandler` is already defined
-    fn DefaultHandler(_irqn: i16) {}
+    unsafe fn DefaultHandler(_irqn: i16) {}
 }

--- a/tests/compile-fail/exception-nmi-unsafe.rs
+++ b/tests/compile-fail/exception-nmi-unsafe.rs
@@ -1,0 +1,24 @@
+#![no_main]
+#![no_std]
+
+extern crate cortex_m_rt;
+extern crate panic_halt;
+
+use cortex_m_rt::{entry, exception};
+
+#[entry]
+fn foo() -> ! {
+    loop {}
+}
+
+#[exception]
+fn DefaultHandler(_irq: i16) {}
+//~^ ERROR defining a `DefaultHandler` is unsafe and requires an `unsafe fn`
+
+#[exception]
+fn HardFault() {}
+//~^ ERROR defining a `HardFault` handler is unsafe and requires an `unsafe fn`
+
+#[exception]
+fn NonMaskableInt() {}
+//~^ ERROR defining a `NonMaskableInt` handler is unsafe and requires an `unsafe fn`

--- a/tests/compile-fail/hard-fault-bad-signature-1.rs
+++ b/tests/compile-fail/hard-fault-bad-signature-1.rs
@@ -12,7 +12,7 @@ fn foo() -> ! {
 }
 
 #[exception]
-fn HardFault(_ef: &ExceptionFrame, undef: u32) -> ! {
-    //~^ ERROR `HardFault` handler must have signature `[unsafe] fn(&ExceptionFrame) -> !`
+unsafe fn HardFault(_ef: &ExceptionFrame, undef: u32) -> ! {
+    //~^ ERROR `HardFault` handler must have signature `unsafe fn(&ExceptionFrame) -> !`
     loop {}
 }

--- a/tests/compile-fail/hard-fault-twice.rs
+++ b/tests/compile-fail/hard-fault-twice.rs
@@ -12,7 +12,7 @@ fn foo() -> ! {
 }
 
 #[exception]
-fn HardFault(_ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(_ef: &ExceptionFrame) -> ! {
     loop {}
 }
 
@@ -20,7 +20,7 @@ pub mod reachable {
     use cortex_m_rt::{exception, ExceptionFrame};
 
     #[exception] //~ ERROR symbol `HardFault` is already defined
-    fn HardFault(_ef: &ExceptionFrame) -> ! {
+    unsafe fn HardFault(_ef: &ExceptionFrame) -> ! {
         loop {}
     }
 }

--- a/tests/compile-fail/unsafe-init-static.rs
+++ b/tests/compile-fail/unsafe-init-static.rs
@@ -29,12 +29,12 @@ fn SVCall() {
 }
 
 #[exception]
-fn DefaultHandler(_irq: i16) {
+unsafe fn DefaultHandler(_irq: i16) {
     static mut X: u32 = init();  //~ ERROR requires unsafe
 }
 
 #[exception]
-fn HardFault(_frame: &cortex_m_rt::ExceptionFrame) -> ! {
+unsafe fn HardFault(_frame: &cortex_m_rt::ExceptionFrame) -> ! {
     static mut X: u32 = init();  //~ ERROR requires unsafe
     loop {}
 }


### PR DESCRIPTION
Reverts https://github.com/rust-embedded/cortex-m-rt/pull/257

Fixes https://github.com/rust-embedded/cortex-m-rt/issues/269
Fixes https://github.com/rust-embedded/cortex-m/issues/196 (see that thread for details)