### PR TITLE
Add a section to place the veneers in memory

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -110,6 +110,18 @@ SECTIONS
   . = ALIGN(4); /* Ensure __erodata is aligned if something unaligned is inserted after .rodata */
   __erodata = .;
 
+  /* ### .gnu.sgstubs
+     This section contains the TrustZone-M veneers put there by the Arm GNU linker. */
+  . = ALIGN(32); /* Security Attribution Unit blocks must be 32 bytes aligned. */
+  __veneer_base = ALIGN(4);
+  .gnu.sgstubs : ALIGN(4)
+  {
+    *(.gnu.sgstubs*)
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+  } > FLASH
+  . = ALIGN(4); /* Ensure __veneer_limit is aligned if something unaligned is inserted after .gnu.sgstubs */
+  __veneer_limit = .;
+
   /* ## Sections in RAM */
   /* ### .data */
   .data : ALIGN(4)


### PR DESCRIPTION
The veneers are for now only generated by the Arm GNU linker when it
spots an entry function (one that was decorated with the
cmse_nonsecure_entry attribute).
Adding this section will allow to configure the SAU to make this section
Non-Secure Callable.

Doing tests locally I could not see any warnings if this section was empty so I think this is fine. It is highly specific to the GNU toolchain so maybe you would want some preprocessing directive and `cfg` options which I am happy to add.

There is documentation for the section name at the end of [this page](https://sourceware.org/binutils/docs/ld/ARM.html).

It needs to be aligned on 32 bytes as a requirement from the Security Attribute Unit.