### PR TITLE
Only emit link_section for cortex-m

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -278,8 +278,10 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
                 #(#attrs)*
                 #[doc(hidden)]
                 #[export_name = "HardFault"]
-                #[cfg_attr(target_os = "macos", link_section = ".HardFault,user")]
-                #[cfg_attr(not(target_os = "macos"), link_section = ".HardFault.user")]
+                // Only emit link_section when building for embedded targets,
+                // because some hosted platforms (used to check the build)
+                // cannot handle the long link section names.
+                #[cfg_attr(target_os = "none", link_section = ".HardFault.user")]
                 pub unsafe extern "C" fn #tramp_ident(frame: &::cortex_m_rt::ExceptionFrame) {
                     #ident(frame)
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -910,15 +910,13 @@ pub fn heap_start() -> *mut u32 {
 
 // Entry point is Reset.
 #[doc(hidden)]
-#[cfg_attr(target_os = "macos", link_section = ".vector_table,reset_vector")]
-#[cfg_attr(not(target_os = "macos"), link_section = ".vector_table.reset_vector")]
+#[cfg_attr(cortex_m, link_section = ".vector_table.reset_vector")]
 #[no_mangle]
 pub static __RESET_VECTOR: unsafe extern "C" fn() -> ! = Reset;
 
 #[allow(unused_variables)]
 #[doc(hidden)]
-#[cfg_attr(target_os = "macos", link_section = ".HardFault,default")]
-#[cfg_attr(not(target_os = "macos"), link_section = ".HardFault.default")]
+#[cfg_attr(cortex_m, link_section = ".HardFault.default")]
 #[no_mangle]
 pub unsafe extern "C" fn HardFault_(ef: &ExceptionFrame) -> ! {
     loop {
@@ -1010,8 +1008,7 @@ pub union Vector {
 }
 
 #[doc(hidden)]
-#[cfg_attr(target_os = "macos", link_section = ".vector_table,exceptions")]
-#[cfg_attr(not(target_os = "macos"), link_section = ".vector_table.exceptions")]
+#[cfg_attr(cortex_m, link_section = ".vector_table.exceptions")]
 #[no_mangle]
 pub static __EXCEPTIONS: [Vector; 14] = [
     // Exception 2: Non Maskable Interrupt.
@@ -1073,8 +1070,7 @@ pub static __EXCEPTIONS: [Vector; 14] = [
 // to the default handler
 #[cfg(all(any(not(feature = "device"), test), not(armv6m)))]
 #[doc(hidden)]
-#[cfg_attr(target_os = "macos", link_section = ".vector_table,interrupts")]
-#[cfg_attr(not(target_os = "macos"), link_section = ".vector_table.interrupts")]
+#[cfg_attr(cortex_m, link_section = ".vector_table.interrupts")]
 #[no_mangle]
 pub static __INTERRUPTS: [unsafe extern "C" fn(); 240] = [{
     extern "C" {


### PR DESCRIPTION
Previously we always emitted `link_section`, even though it only had an
effect when our linker script was being used (and only made sense on
cortex-m targets). This breaks building the code for a MacOS target,
which is occasionally useful for running `cargo check` etc.

In the macros crate we don't have the target information available, so
instead we continue to emit `link_section` except specifically on MacOS.

This keeps the fix from #306 but hopefully resolves the confusion in https://github.com/rust-embedded/cortex-m-rt/issues/74#issuecomment-768079657.