### PR TITLE
Use volatile read for ICSR register

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -227,7 +227,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
 
                     const SCB_ICSR: *const u32 = 0xE000_ED04 as *const u32;
 
-                    let irqn = unsafe { core::ptr::read_volatile(SCB_ICSR) as u8 as i16 - 16 };
+                    let irqn = unsafe { (core::ptr::read_volatile(SCB_ICSR) & 0x1FF) as i16 - 16 };
 
                     #ident(irqn)
                 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -227,7 +227,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
 
                     const SCB_ICSR: *const u32 = 0xE000_ED04 as *const u32;
 
-                    let irqn = unsafe { core::ptr::read(SCB_ICSR) as u8 as i16 - 16 };
+                    let irqn = unsafe { core::ptr::read_volatile(SCB_ICSR) as u8 as i16 - 16 };
 
                     #ident(irqn)
                 }


### PR DESCRIPTION
This prevents the compiler from optimizing the read.

Edit: I also added a change to include the 9th bit in the IRQ. I can leave that out if it would break anything. 

#314