### PR TITLE
bump version to 0.6.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m-rt"
-version = "0.6.11"
+version = "0.6.13"
 autoexamples = true
 links = "cortex-m-rt" # Prevent multiple versions of cortex-m-rt being linked
 


### PR DESCRIPTION
The currently released version is 0.6.13 but the version in Cargo.toml was still 0.6.11.
This enables cargo-patching in the git repository if other crates need newer cortex-m-rt.