### PR TITLE
Prepare for v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,27 +11,35 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add support for CMSE secure gateway veneers ([#297]).
 - Allow using the crate with custom target JSON specs ([#304]).
+- Export Exception enum for other crates to use ([#224])
 
+[#224]: https://github.com/rust-embedded/cortex-m-rt/pull/224
 [#297]: https://github.com/rust-embedded/cortex-m-rt/pull/297
 [#304]: https://github.com/rust-embedded/cortex-m-rt/pull/304
 
 ### Fixes
 
-- Various fixes to the linker script ([#265], [#286]).
+- Various fixes to the linker script ([#265], [#286], [#287], [#323]).
 - Use the correct ABI for the `main` symbol ([#278]).
 - Add barriers after FPU enabling ([#279]).
-- (ARMv6-M) Set LR value to a known value on reset (as the ARM spec requires)
-- Added CFI and size info to external assembly subroutines (`HardFaultTrampoline` and `FpuTrampoline`)
+- (ARMv6-M) Set LR value to a known value on reset (#[293])
+- Added CFI and size info to external assembly subroutines (`HardFaultTrampoline` and `FpuTrampoline`) ([#294])
 - Allow building the crate for macOS targets ([#306], [#310]).
 - Perform RAM initialization in assembly, to avoid potential UB in Rust ([#301]).
+- Perform volatile reads of ICSR in DefaultHandler (#[315])
 
 [#265]: https://github.com/rust-embedded/cortex-m-rt/pull/265
 [#278]: https://github.com/rust-embedded/cortex-m-rt/pull/278
 [#279]: https://github.com/rust-embedded/cortex-m-rt/pull/279
 [#286]: https://github.com/rust-embedded/cortex-m-rt/pull/286
+[#287]: https://github.com/rust-embedded/cortex-m-rt/pull/287
+[#293]: https://github.com/rust-embedded/cortex-m-rt/pull/293
+[#294]: https://github.com/rust-embedded/cortex-m-rt/pull/294
 [#301]: https://github.com/rust-embedded/cortex-m-rt/pull/301
 [#306]: https://github.com/rust-embedded/cortex-m-rt/pull/306
 [#310]: https://github.com/rust-embedded/cortex-m-rt/pull/310
+[#315]: https://github.com/rust-embedded/cortex-m-rt/pull/315
+[#323]: https://github.com/rust-embedded/cortex-m-rt/pull/323
 
 ### Breaking Changes
 
@@ -48,14 +56,54 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#289]: https://github.com/rust-embedded/cortex-m-rt/pull/289
 [#308]: https://github.com/rust-embedded/cortex-m-rt/pull/308
 
-## [v0.6.13] - 2020-09-07
+### Other
+
+- Change macros crate to use same version number as cortex-m-rt crate ([#245])
+- Discourage use of `pre_init` in documentation ([#248])
+- Backport: Use `links` in Cargo.toml to prevent multiple linking of
+  cortex-m-rt (#276)
+
+[#245]: https://github.com/rust-embedded/cortex-m-rt/pull/245
+[#248]: https://github.com/rust-embedded/cortex-m-rt/pull/248
+[#276]: https://github.com/rust-embedded/cortex-m-rt/pull/276
+
+## Backport release: [v0.6.15] - 2021-07-12
+
+### Fixed
+
+- Backport: Mark .bss as NOLOAD ([#265])
+- Backport: Fix possible overflow of .data region ([#286])
+- Backport: Perform volatile reads of ICSR in DefaultHandler (#[315])
+
+### Other
+- Backport: Use `links` in Cargo.toml to prevent multiple linking of
+  cortex-m-rt (#276)
+- Backport: Use same verison for macros crate as for cortex-m-rt itself
+  ([#245])
+
+[#245]: https://github.com/rust-embedded/cortex-m-rt/pull/245
+[#265]: https://github.com/rust-embedded/cortex-m-rt/pull/265
+[#276]: https://github.com/rust-embedded/cortex-m-rt/pull/276
+[#286]: https://github.com/rust-embedded/cortex-m-rt/pull/286
+[#315]: https://github.com/rust-embedded/cortex-m-rt/pull/315
+
+## [v0.6.14] - 2021-05-19
+
+### Fixed
+
+- Backport: Allow building the crate for macOS targets ([#306], [#310]).
+
+[#306]: https://github.com/rust-embedded/cortex-m-rt/issues/306
+[#310]: https://github.com/rust-embedded/cortex-m-rt/issues/310
+
+## Backport release: [v0.6.13] - 2020-09-07
 
 ### Fixed
 
 - (ARMv6-M) Set LR value to a known value on reset (as the ARM spec requires)
 - Added CFI and size info to external assembly subroutines (`HardFaultTrampoline`)
 
-## [v0.6.12] - 2020-01-26
+## Backport release: [v0.6.12] - 2020-01-26
 
 ### Fixed
 
@@ -522,7 +570,9 @@ section                size        addr
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.6.13...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.6.11...HEAD
+[v0.6.15]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.6.14...v0.6.15
+[v0.6.14]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.6.13...v0.6.14
 [v0.6.13]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.6.12...v0.6.13
 [v0.6.12]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.6.11...v0.6.12
 [v0.6.11]: https://github.com/rust-embedded/cortex-m-rt/compare/v0.6.10...v0.6.11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-m-rt"
-version = "0.6.13"
+version = "0.7.0"
 autoexamples = true
 links = "cortex-m-rt" # Prevent multiple versions of cortex-m-rt being linked
 
 [dependencies]
-cortex-m-rt-macros = { path = "macros", version = "=0.6.11" }
+cortex-m-rt-macros = { path = "macros", version = "=0.7.0" }
 # Note: Do not depend on `cortex-m` here. This crate is used for testing `cortex-m`, so we need to
 # avoid pulling in multiple versions of `cortex-m`.
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -41,7 +41,10 @@ main() {
         ""
     )
     if [ "$TARGET" != x86_64-unknown-linux-gnu ]; then
-        RUSTDOCFLAGS="-Cpanic=abort" cargo test --doc
+        # Only test on stable and nightly, not MSRV.
+        if [ "$TRAVIS_RUST_VERSION" = stable ] || [ "$TRAVIS_RUST_VERSION" = nightly ]; then
+            RUSTDOCFLAGS="-Cpanic=abort" cargo test --doc
+        fi
 
         for linker in "${linkers[@]}"; do
             for ex in "${examples[@]}"; do

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["arm", "cortex-m", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-rt-macros"
 repository = "https://github.com/rust-embedded/cortex-m-rt"
-version = "0.6.11"
+version = "0.7.0"
 edition = "2018"
 
 [lib]


### PR DESCRIPTION
This is mostly a changelog update, including the updates from 0.6 and adding a few missing PRs too.

I haven't yet reviewed our open issues but I'm sure there are some low-hanging fruit we should get in for this release, does anyone have any suggestions? I'm happy to update this PR a few times if we can get a few more changes landed first.