### PR TITLE
Make the address of the vector table configurable.

### DIFF
--- a/link.x.in
+++ b/link.x.in
@@ -63,8 +63,11 @@ SECTIONS
   PROVIDE(_stack_start = ORIGIN(RAM) + LENGTH(RAM));
 
   /* ## Sections in FLASH */
+  
+  PROVIDE(_svector_table = ORIGIN(FLASH));
+  
   /* ### Vector table */
-  .vector_table ORIGIN(FLASH) :
+  .vector_table _svector_table :
   {
     /* Initial Stack Pointer (SP) value */
     LONG(_stack_start);


### PR DESCRIPTION
Not sure if this is the right way to do it; please let me know if there's a better alternative. I'm trying to add dummy sections for a bootloader header and trailer, this change allows my `memory.x` file to be pretty clear:

```
MEMORY
{
  /* NOTE K = KiBi = 1024 bytes */
  FLASH : ORIGIN = 0x00008000, LENGTH = 464K
  RAM : ORIGIN = 0x20000000, LENGTH = 64K
}

SECTIONS
{
  .mcuboot_header 0x8000 :
  {
    FILL(0xAAAAAAAA)
    . = . + 32;
  } > FLASH
  PROVIDE(_svector_table = 0x8020);
}
INSERT BEFORE .vector_table;

SECTIONS
{
  .mcuboot_trailer . :
  {
    FILL(0xFFFFFFFF)
    . = . + 40;
  } > FLASH
}
INSERT AFTER .gnu.sgstubs;
```